### PR TITLE
fix: correct rendering bugs, type safety, and migration test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ pnpm exec jest --testNamePattern="Min Needle"
    and memoized render calls, produces the final SVG layout.
 
 4. **`src/migrations.ts`** — `PanelMigrationHandler()` migrates persisted panel configs
-   across plugin versions.
+   across plugin versions. Defines typed Angular migration interfaces
+   (`AngularPanel`, `AngularPanelProperties`, `AngularFieldConfig`, `AngularOptions`).
 
 ### Gauge Internals (`src/components/Gauge/`)
 
@@ -215,7 +216,7 @@ pnpm exec playwright test --ui    # Interactive UI mode
 | Custom hooks        | `use<Name>.ts`                    | `useNeedleAnimation.ts`                 |
 | Style files         | `<scope>_styles.ts`               | `gauge_styles.ts`                       |
 | Constants           | `SCREAMING_SNAKE_CASE`            | `DEFAULT_GAUGE_OPTIONS`                 |
-| Interfaces          | PascalCase                        | `GaugeOptions`, `TickMapItem`           |
+| Interfaces          | PascalCase                        | `GaugeOptions`, `TickMapItemType`       |
 | Functions/variables | camelCase                         | `computeNeedleAngle`, `getDisplayValue` |
 
 ### TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All changes noted here.
 
 ## v2.0.5 (unreleased)
 
+### Bug Fixes (Rendering and Migration)
+
+- Fix `for...in` iterating array indices instead of values in
+  `renderMajorTickLabels`, causing incorrect `maxLabelLength` calculation
+  for font scaling
+- Fix falsy-zero bug where `displayValue` of `0` skipped threshold
+  coloring in `renderCircleGroup`, `valueColor`, and `titleColor`
+- Add React `key` props to threshold band elements to fix missing key
+  warnings and prevent incorrect reconciliation
+- Fix `migrateTickMaps` missing `enabled` field in return value
+- Fix marker shape migration assigning `MarkerType` object to `string`
+  field (now correctly extracts `.name`)
+
+### Type Safety
+
+- Replace `any` type on `dToR` parameter with `number`
+- Replace `any` types on `panelHeight`/`panelWidth` with `number`
+- Add `AngularPanelProperties` interface and `AngularPanel` type for
+  migration code, eliminating all 38 `@ts-ignore` suppressions
+- Add `AngularFieldConfig` interface for angular fieldConfig migration
+- Type `migrateValueAndRangeMaps` parameter (was `any`)
+- Replace `return {} as any` with `return {}` in `PanelMigrationHandler`
+
+### Cleanup
+
+- Remove unused `GaugeModel` interface
+- Remove commented-out `MarkerStartShapes`/`MarkerEndShapes` arrays
+- Remove unused `GaugePresetOptions` imports and commented-out preset block
+- Remove unused `PanelChangedHandler` export
+- Remove unused `React` import in `needle_utils.tsx`
+- Remove unexposed `needleLengthNegCalc` from `useGaugeDimensions` return
+
 ### CI
 
 - Replace reusable `grafana/plugin-ci-workflows@v7` with inline workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All changes noted here.
   for font scaling
 - Fix falsy-zero bug where `displayValue` of `0` skipped threshold
   coloring in `renderCircleGroup`, `valueColor`, and `titleColor`
+  (use strict `!== null` check matching the `number | null` type)
 - Add React `key` props to threshold band elements to fix missing key
   warnings and prevent incorrect reconciliation
 - Fix `migrateTickMaps` missing `enabled` field in return value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All changes noted here.
 - Remove unused `React` import in `needle_utils.tsx`
 - Remove unexposed `needleLengthNegCalc` from `useGaugeDimensions` return
 
+### Testing
+
+- Add 34 migration tests covering `convertOperators`, `migrateTickMaps`,
+  `migrateFieldConfig`, `migrateValueAndRangeMaps`, `migrateDefaults`,
+  and full `PanelMigrationHandler` integration (threshold migration with
+  custom/default colors, format migration, angular property cleanup)
+- Migration tests: 4 → 38, total suite: 200 → 234
+
 ### CI
 
 - Replace reusable `grafana/plugin-ci-workflows@v7` with inline workflow

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -150,14 +150,14 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
   ]);
 
   const valueColor = useMemo(() => {
-    if (options.showThresholdStateOnValue && options.displayValue != null && options.thresholds) {
+    if (options.showThresholdStateOnValue && options.displayValue !== null && options.thresholds) {
       return getActiveThreshold(options.displayValue, options.thresholds.steps).color;
     }
     return options.unitsLabelColor;
   }, [options.showThresholdStateOnValue, options.displayValue, options.thresholds, options.unitsLabelColor]);
 
   const titleColor = useMemo(() => {
-    if (options.showThresholdStateOnTitle && options.displayValue != null && options.thresholds) {
+    if (options.showThresholdStateOnTitle && options.displayValue !== null && options.thresholds) {
       return getActiveThreshold(options.displayValue, options.thresholds.steps).color;
     }
     return options.unitsLabelColor;

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -150,14 +150,14 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
   ]);
 
   const valueColor = useMemo(() => {
-    if (options.showThresholdStateOnValue && options.displayValue && options.thresholds) {
+    if (options.showThresholdStateOnValue && options.displayValue != null && options.thresholds) {
       return getActiveThreshold(options.displayValue, options.thresholds.steps).color;
     }
     return options.unitsLabelColor;
   }, [options.showThresholdStateOnValue, options.displayValue, options.thresholds, options.unitsLabelColor]);
 
   const titleColor = useMemo(() => {
-    if (options.showThresholdStateOnTitle && options.displayValue && options.thresholds) {
+    if (options.showThresholdStateOnTitle && options.displayValue != null && options.thresholds) {
       return getActiveThreshold(options.displayValue, options.thresholds.steps).color;
     }
     return options.unitsLabelColor;

--- a/src/components/Gauge/gauge_render.tsx
+++ b/src/components/Gauge/gauge_render.tsx
@@ -29,7 +29,7 @@ export const renderCircleGroup = (
 ) => {
   let gaugeFaceColor = innerColor;
   if (showThresholdStateOnBackground) {
-    if (displayValue != null && thresholds) {
+    if (displayValue !== null && thresholds) {
       const aThreshold = getActiveThreshold(displayValue, thresholds.steps);
       gaugeFaceColor = aThreshold.color;
     }

--- a/src/components/Gauge/gauge_render.tsx
+++ b/src/components/Gauge/gauge_render.tsx
@@ -29,7 +29,7 @@ export const renderCircleGroup = (
 ) => {
   let gaugeFaceColor = innerColor;
   if (showThresholdStateOnBackground) {
-    if (displayValue && thresholds) {
+    if (displayValue != null && thresholds) {
       const aThreshold = getActiveThreshold(displayValue, thresholds.steps);
       gaugeFaceColor = aThreshold.color;
     }
@@ -151,7 +151,7 @@ export const renderMajorTickLabels = (
   theme: GrafanaTheme2
 ) => {
   let maxLabelLength = 0;
-  for (const item in tickMajorLabels) {
+  for (const item of tickMajorLabels) {
     if (item.length > maxLabelLength) {
       maxLabelLength = item.length;
     }
@@ -304,15 +304,24 @@ export const renderThresholdBands = (
     <>
       {showThresholdBandLowerRange &&
         lowerBand &&
-        drawBand(lowerBand.min, lowerBand.max, lowerBand.color, originX, originY, bandOptions, theme)}
+        drawBand(lowerBand.min, lowerBand.max, lowerBand.color, originX, originY, bandOptions, theme, 'band-lower')}
       {showThresholdBandMiddleRange &&
         innerBands &&
         innerBands.map((aBand: ExpandedThresholdBand) => {
-          return drawBand(aBand.min, aBand.max, aBand.color, originX, originY, bandOptions, theme);
+          return drawBand(
+            aBand.min,
+            aBand.max,
+            aBand.color,
+            originX,
+            originY,
+            bandOptions,
+            theme,
+            `band-middle-${aBand.index}`
+          );
         })}
       {showThresholdBandUpperRange &&
         upperBand &&
-        drawBand(upperBand.min, upperBand.max, upperBand.color, originX, originY, bandOptions, theme)}
+        drawBand(upperBand.min, upperBand.max, upperBand.color, originX, originY, bandOptions, theme, 'band-upper')}
     </>
   );
 };

--- a/src/components/Gauge/needle_utils.tsx
+++ b/src/components/Gauge/needle_utils.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 /**
  * getNeedleAngleMinimum
  *

--- a/src/components/Gauge/useGaugeDimensions.test.ts
+++ b/src/components/Gauge/useGaugeDimensions.test.ts
@@ -55,11 +55,6 @@ describe('useGaugeDimensions', () => {
       expect(result.current.needleWidth).toBe(1);
     });
 
-    it('computes needleLengthNegCalc as gaugeRadius * needleLengthNeg', () => {
-      const { result } = renderHook(() => useGaugeDimensions(defaultOpts));
-      expect(result.current.needleLengthNegCalc).toBe(20);
-    });
-
     it('scales tickWidthMajorCalc by radius / basis ratio', () => {
       const { result } = renderHook(() => useGaugeDimensions(defaultOpts));
       // 3 * (200 / 200) = 3

--- a/src/components/Gauge/useGaugeDimensions.ts
+++ b/src/components/Gauge/useGaugeDimensions.ts
@@ -35,7 +35,6 @@ export const useGaugeDimensions = (opts: GaugeDimensionOptions) => {
     return {
       SVGSize: opts.gaugeRadius * 2,
       needleWidth: opts.needleWidth * (opts.gaugeRadius / opts.ticknessGaugeBasis),
-      needleLengthNegCalc,
       tickWidthMajorCalc: opts.tickWidthMajor * (opts.gaugeRadius / opts.ticknessGaugeBasis),
       tickWidthMinorCalc: opts.tickWidthMinor * (opts.gaugeRadius / opts.ticknessGaugeBasis),
       outerEdgeRadius: opts.gaugeRadius - opts.padding,

--- a/src/components/Gauge/utils.tsx
+++ b/src/components/Gauge/utils.tsx
@@ -3,7 +3,7 @@ import { arc, line } from 'd3';
 import { GaugeOptions, MarkerType, Markers } from '../types';
 import { GrafanaTheme2 } from '@grafana/data';
 
-export const dToR = (angleDeg: any) => {
+export const dToR = (angleDeg: number) => {
   // Turns an angle in degrees to radians
   const angleRad = angleDeg * (Math.PI / 180);
   return angleRad;

--- a/src/components/Gauge/utils.tsx
+++ b/src/components/Gauge/utils.tsx
@@ -72,7 +72,8 @@ export const drawBand = (
   originX: number,
   originY: number,
   options: GaugeOptions,
-  theme2: GrafanaTheme2
+  theme2: GrafanaTheme2,
+  bandKey?: string
 ) => {
   const anArc = arc();
   const vToROptions: ValueToRadiansOptions = {
@@ -93,16 +94,16 @@ export const drawBand = (
     endAngle: endAngle,
   });
 
+  if (!xc) {
+    return null;
+  }
   return (
-    <>
-      {xc && (
-        <path
-          fill={theme2.visualization.getColorByName(color)}
-          d={xc || ''}
-          transform={`translate(${originX},${originY}) rotate(${options.maxTickAngle})`}
-        />
-      )}
-    </>
+    <path
+      key={bandKey}
+      fill={theme2.visualization.getColorByName(color)}
+      d={xc}
+      transform={`translate(${originX},${originY}) rotate(${options.maxTickAngle})`}
+    />
   );
 };
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -203,15 +203,3 @@ export interface ExpandedThresholdBand {
   max: number;
   color: string;
 }
-
-export interface GaugePresetType {
-  id: number;
-  name: string;
-  faceColor: string;
-}
-
-export const GaugePresetOptions: GaugePresetType[] = [
-  { id: 0, name: 'Default', faceColor: '#FFFFFF' },
-  { id: 1, name: 'Red', faceColor: '#FF0000' },
-  { id: 2, name: 'Compass', faceColor: '#00F0FF' },
-];

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -66,8 +66,8 @@ export interface GaugeOptions {
   tickSpacingMajor: number;
   tickSpacingMinor: number;
   // passed in by grafana
-  panelHeight?: any;
-  panelWidth?: any;
+  panelHeight?: number;
+  panelWidth?: number;
   panelId?: number;
 
   // tickmaps

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -89,9 +89,6 @@ export interface GaugeOptions {
   thresholds: ThresholdsConfig | undefined;
 }
 
-// tslint:disable-next-line
-export interface GaugeModel {}
-
 export enum FontFamilies {
   ARIAL = 'Arial',
   HELVETICA = 'Helvetica',
@@ -191,18 +188,6 @@ export const Markers: MarkerType[] = [
   { id: 3, name: 'stub', path: 'M 0,0 m -1,-5 L 1,-5 L 1,5 L -1,5 Z', viewBox: '-1 -5 2 10' },
   { id: 4, name: 'arrow-inverse', path: 'M 0,0 m 5,5 L -5,0 L 5,-5 Z', viewBox: '-5 -5 10 10' },
 ];
-
-/*
-export const MarkerStartShapes = [
-  { id: 0, name: 'circle' },
-  { id: 1, name: 'square' },
-  { id: 2, name: 'stub' },
-];
-
-export const MarkerEndShapes = [
-  { id: 0, name: 'arrow' }
-];
-*/
 
 export const MarkerOptions: SelectableValue[] = [
   { value: 'arrow', label: 'arrow' },

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -1,7 +1,16 @@
-import { PanelModel } from '@grafana/data';
+import { PanelModel, ThresholdsMode } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-import { PanelMigrationHandler, hasRobotoFont } from './migrations';
+import { FontFamilies, GaugeOptions } from './components/types';
+import {
+  PanelMigrationHandler,
+  convertOperators,
+  migrateDefaults,
+  migrateFieldConfig,
+  migrateTickMaps,
+  migrateValueAndRangeMaps,
+  hasRobotoFont,
+} from './migrations';
 
 describe('D3Gauge -> D3GaugeV2 migrations', () => {
   it('migrates empty d3gauge', () => {
@@ -79,5 +88,625 @@ describe('D3Gauge -> D3GaugeV2 migrations', () => {
       config.buildInfo.version = key;
       expect(hasRobotoFont()).toEqual(value);
     }
+  });
+});
+
+describe('convertOperators', () => {
+  it('converts avg to mean', () => {
+    expect(convertOperators('avg')).toBe('mean');
+  });
+
+  it('converts current to last', () => {
+    expect(convertOperators('current')).toBe('last');
+  });
+
+  it('converts time_step to step', () => {
+    expect(convertOperators('time_step')).toBe('step');
+  });
+
+  it('converts total to sum', () => {
+    expect(convertOperators('total')).toBe('sum');
+  });
+
+  it('passes through unknown operators unchanged', () => {
+    expect(convertOperators('max')).toBe('max');
+    expect(convertOperators('min')).toBe('min');
+    expect(convertOperators('mean')).toBe('mean');
+  });
+
+  it('passes through empty string', () => {
+    expect(convertOperators('')).toBe('');
+  });
+});
+
+describe('migrateTickMaps', () => {
+  it('returns empty tick maps for empty input', () => {
+    const result = migrateTickMaps([]);
+    expect(result).toEqual({
+      tickMaps: [],
+      enabled: true,
+    });
+  });
+
+  it('converts angular tick maps to new format', () => {
+    const angularTickMaps = [
+      { value: '10', text: 'Low' },
+      { value: '50', text: 'Mid' },
+      { value: '90', text: 'High' },
+    ];
+    const result = migrateTickMaps(angularTickMaps);
+    expect(result.tickMaps).toHaveLength(3);
+    expect(result.enabled).toBe(true);
+    expect(result.tickMaps[0]).toEqual({
+      label: 'Label-0',
+      value: '10',
+      text: 'Low',
+      enabled: true,
+      order: 0,
+    });
+    expect(result.tickMaps[1]).toEqual({
+      label: 'Label-1',
+      value: '50',
+      text: 'Mid',
+      enabled: true,
+      order: 1,
+    });
+    expect(result.tickMaps[2]).toEqual({
+      label: 'Label-2',
+      value: '90',
+      text: 'High',
+      enabled: true,
+      order: 2,
+    });
+  });
+
+  it('converts a single tick map', () => {
+    const result = migrateTickMaps([{ value: '0', text: 'Zero' }]);
+    expect(result.tickMaps).toHaveLength(1);
+    expect(result.tickMaps[0].value).toBe('0');
+    expect(result.tickMaps[0].text).toBe('Zero');
+    expect(result.tickMaps[0].order).toBe(0);
+  });
+});
+
+describe('migrateFieldConfig', () => {
+  const makePanel = (overrides: Record<string, unknown> = {}) =>
+    ({
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      ...overrides,
+    }) as any;
+
+  it('migrates decimals to fieldConfig', () => {
+    const panel = makePanel({ decimals: 3 });
+    const fieldConfig = { defaults: {}, overrides: [] } as any;
+    const result = migrateFieldConfig(panel, fieldConfig);
+    expect(result.decimals).toBe(3);
+    expect(panel.decimals).toBeUndefined();
+  });
+
+  it('migrates gauge units to fieldConfig', () => {
+    const panel = makePanel({
+      gauge: {
+        gaugeUnits: 'percent',
+      },
+    });
+    const fieldConfig = { defaults: {}, overrides: [] } as any;
+    const result = migrateFieldConfig(panel, fieldConfig);
+    expect(result.unit).toBe('percent');
+  });
+
+  it('does not set unit when gauge has no gaugeUnits', () => {
+    const panel = makePanel({
+      gauge: {
+        gaugeUnits: '',
+      },
+    });
+    const fieldConfig = { defaults: {}, overrides: [] } as any;
+    const result = migrateFieldConfig(panel, fieldConfig);
+    expect(result.unit).toBeUndefined();
+  });
+
+  it('returns fieldConfig unchanged when no angular properties present', () => {
+    const panel = makePanel();
+    const fieldConfig = { defaults: {}, overrides: [] } as any;
+    const result = migrateFieldConfig(panel, fieldConfig);
+    expect(result).toEqual({ defaults: {}, overrides: [] });
+  });
+});
+
+describe('migrateValueAndRangeMaps', () => {
+  const makePanel = (overrides: Record<string, unknown> = {}) =>
+    ({
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      ...overrides,
+    }) as any;
+
+  it('returns empty array when no maps exist', () => {
+    const panel = makePanel();
+    const result = migrateValueAndRangeMaps(panel);
+    expect(result).toEqual([]);
+  });
+
+  it('sets mappingType to 1 for value maps then 2 for range maps', () => {
+    const panel = makePanel();
+    migrateValueAndRangeMaps(panel);
+    // After execution, mappingType should be 2 (last assignment)
+    expect(panel.mappingType).toBe(2);
+  });
+});
+
+describe('migrateDefaults', () => {
+  // Minimal AngularOptions with all required fields at zero/empty values
+  const makeAngularOptions = (overrides: Record<string, unknown> = {}) =>
+    ({
+      minValue: 0,
+      maxValue: 0,
+      tickSpaceMinVal: 0,
+      tickSpaceMajVal: 0,
+      gaugeUnits: '',
+      gaugeRadius: 0,
+      pivotRadius: 0,
+      padding: 0,
+      edgeWidth: 0,
+      tickEdgeGap: 0,
+      tickLengthMaj: 0,
+      tickLengthMin: 0,
+      needleTickGap: 0,
+      needleLengthNeg: 0,
+      ticknessGaugeBasis: 0,
+      needleWidth: 0,
+      outerEdgeCol: '',
+      innerCol: '',
+      pivotCol: '',
+      tickColMaj: '',
+      tickColMin: '',
+      tickLabelCol: '',
+      unitsLabelCol: '',
+      show: false,
+      showLowerThresholdRange: false,
+      showMiddleThresholdRange: false,
+      showUpperThresholdRange: false,
+      showThresholdColorOnBackground: false,
+      showThresholdColorOnValue: false,
+      showThresholdOnGauge: false,
+      thresholdColors: [],
+      tickFont: '',
+      unitsFont: '',
+      unitsLabelFontSize: 0,
+      labelFontSize: 0,
+      tickWidthMaj: 0,
+      tickWidthMin: 0,
+      zeroNeedleAngle: 0,
+      zeroTickAngle: 0,
+      decimals: 0,
+      format: '',
+      operatorName: '',
+      ...overrides,
+    }) as any;
+
+  it('returns default values when angular options are all zero/empty', () => {
+    const result = migrateDefaults(makeAngularOptions());
+    expect(result.minValue).toBe(0);
+    expect(result.maxValue).toBe(100);
+    expect(result.gaugeRadius).toBe(0);
+    expect(result.outerEdgeColor).toBe('#0099cc');
+    expect(result.innerColor).toBe('#ffffff');
+    expect(result.pivotColor).toBe('#999999');
+    expect(result.needleColor).toBe('#0099cc');
+    expect(result.tickFont).toBe(FontFamilies.INTER);
+    expect(result.valueFont).toBe(FontFamilies.INTER);
+    expect(result.animateNeedleValueTransition).toBe(true);
+    expect(result.showThresholdBandOnGauge).toBe(false);
+    expect(result.showThresholdBandLowerRange).toBe(false);
+    expect(result.showThresholdBandMiddleRange).toBe(false);
+    expect(result.showThresholdBandUpperRange).toBe(false);
+  });
+
+  it('migrates limit values', () => {
+    const result = migrateDefaults(makeAngularOptions({ minValue: -50, maxValue: 200 }));
+    expect(result.minValue).toBe(-50);
+    expect(result.maxValue).toBe(200);
+  });
+
+  it('migrates tick spacing', () => {
+    const result = migrateDefaults(makeAngularOptions({ tickSpaceMajVal: 25, tickSpaceMinVal: 5 }));
+    expect(result.tickSpacingMajor).toBe(25);
+    expect(result.tickSpacingMinor).toBe(5);
+  });
+
+  it('migrates radius settings', () => {
+    const result = migrateDefaults(makeAngularOptions({ gaugeRadius: 150, pivotRadius: 0.15 }));
+    expect(result.gaugeRadius).toBe(150);
+    expect(result.pivotRadius).toBe(0.15);
+  });
+
+  it('migrates padding, edgeWidth, and tickEdgeGap', () => {
+    const result = migrateDefaults(makeAngularOptions({ padding: 0.1, edgeWidth: 0.08, tickEdgeGap: 0.03 }));
+    expect(result.padding).toBe(0.1);
+    expect(result.edgeWidth).toBe(0.08);
+    expect(result.tickEdgeGap).toBe(0.03);
+  });
+
+  it('migrates tick lengths', () => {
+    const result = migrateDefaults(makeAngularOptions({ tickLengthMaj: 0.2, tickLengthMin: 0.08 }));
+    expect(result.tickLengthMaj).toBe(0.2);
+    expect(result.tickLengthMin).toBe(0.08);
+  });
+
+  it('migrates needle settings', () => {
+    const result = migrateDefaults(
+      makeAngularOptions({ needleTickGap: 0.1, needleLengthNeg: 0.3, needleWidth: 8, ticknessGaugeBasis: 250 })
+    );
+    expect(result.needleTickGap).toBe(0.1);
+    expect(result.needleLengthNeg).toBe(0.3);
+    expect(result.needleWidth).toBe(8);
+    expect(result.ticknessGaugeBasis).toBe(250);
+  });
+
+  it('migrates color settings with renamed properties', () => {
+    const result = migrateDefaults(
+      makeAngularOptions({
+        outerEdgeCol: '#ff0000',
+        innerCol: '#00ff00',
+        pivotCol: '#0000ff',
+        tickColMaj: '#111111',
+        tickColMin: '#222222',
+        tickLabelCol: '#333333',
+        unitsLabelCol: '#444444',
+      })
+    );
+    expect(result.outerEdgeColor).toBe('#ff0000');
+    expect(result.innerColor).toBe('#00ff00');
+    expect(result.pivotColor).toBe('#0000ff');
+    expect(result.tickMajorColor).toBe('#111111');
+    expect(result.tickMinorColor).toBe('#222222');
+    expect(result.tickLabelColor).toBe('#333333');
+    expect(result.unitsLabelColor).toBe('#444444');
+  });
+
+  it('migrates threshold band visibility settings', () => {
+    const result = migrateDefaults(
+      makeAngularOptions({
+        showLowerThresholdRange: true,
+        showMiddleThresholdRange: true,
+        showUpperThresholdRange: true,
+        showThresholdColorOnBackground: true,
+        showThresholdColorOnValue: true,
+        showThresholdOnGauge: true,
+      })
+    );
+    expect(result.showThresholdBandLowerRange).toBe(true);
+    expect(result.showThresholdBandMiddleRange).toBe(true);
+    expect(result.showThresholdBandUpperRange).toBe(true);
+    expect(result.showThresholdStateOnBackground).toBe(true);
+    expect(result.showThresholdStateOnValue).toBe(true);
+    expect(result.showThresholdBandOnGauge).toBe(true);
+  });
+
+  it('migrates font settings', () => {
+    const result = migrateDefaults(makeAngularOptions({ tickFont: 'Arial', unitsFont: 'Helvetica' }));
+    expect(result.tickFont).toBe('Arial');
+    expect(result.valueFont).toBe('Helvetica');
+  });
+
+  it('migrates tick width settings with renamed properties', () => {
+    const result = migrateDefaults(makeAngularOptions({ tickWidthMaj: 7, tickWidthMin: 2 }));
+    expect(result.tickWidthMajor).toBe(7);
+    expect(result.tickWidthMinor).toBe(2);
+  });
+
+  it('migrates font size settings', () => {
+    const result = migrateDefaults(makeAngularOptions({ unitsLabelFontSize: 30, labelFontSize: 14 }));
+    expect(result.valueFontSize).toBe(30);
+    expect(result.tickLabelFontSize).toBe(14);
+  });
+
+  it('migrates needle angle settings', () => {
+    const result = migrateDefaults(makeAngularOptions({ zeroNeedleAngle: 50, zeroTickAngle: 70 }));
+    expect(result.zeroNeedleAngle).toBe(50);
+    expect(result.zeroTickAngle).toBe(70);
+  });
+});
+
+describe('PanelMigrationHandler (full angular panel)', () => {
+  it('returns empty object when panel has no options and no gauge', () => {
+    const panel = {
+      id: 0,
+      type: 'panel',
+      fieldConfig: { defaults: {}, overrides: [] },
+    } as unknown as PanelModel<GaugeOptions>;
+    const result = PanelMigrationHandler(panel);
+    expect(result).toEqual({});
+  });
+
+  it('returns existing options when panel is not angular', () => {
+    const existingOptions = { minValue: 10, maxValue: 200 } as GaugeOptions;
+    const panel = {
+      id: 0,
+      type: 'panel',
+      options: existingOptions,
+      fieldConfig: { defaults: {}, overrides: [] },
+    } as PanelModel<GaugeOptions>;
+    const result = PanelMigrationHandler(panel);
+    expect(result).toBe(existingOptions);
+  });
+
+  it('migrates a full angular panel with gauge, thresholds, and tickMaps', () => {
+    const panel = {
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      gauge: {
+        minValue: 0,
+        maxValue: 500,
+        tickSpaceMinVal: 5,
+        tickSpaceMajVal: 50,
+        gaugeUnits: 'bytes',
+        gaugeRadius: 200,
+        pivotRadius: 0.1,
+        padding: 0.05,
+        edgeWidth: 0.05,
+        tickEdgeGap: 0.05,
+        tickLengthMaj: 0.15,
+        tickLengthMin: 0.05,
+        needleTickGap: 0.05,
+        needleLengthNeg: 0.2,
+        ticknessGaugeBasis: 200,
+        needleWidth: 5,
+        outerEdgeCol: '#0099cc',
+        innerCol: '#ffffff',
+        pivotCol: '#999999',
+        tickColMaj: '#0099cc',
+        tickColMin: '#000000',
+        tickLabelCol: '#000000',
+        unitsLabelCol: '#000000',
+        show: true,
+        showLowerThresholdRange: true,
+        showMiddleThresholdRange: false,
+        showUpperThresholdRange: true,
+        showThresholdColorOnBackground: false,
+        showThresholdColorOnValue: true,
+        showThresholdOnGauge: true,
+        thresholdColors: [],
+        tickFont: 'Arial',
+        unitsFont: 'Helvetica',
+        unitsLabelFontSize: 20,
+        labelFontSize: 16,
+        tickWidthMaj: 5,
+        tickWidthMin: 1,
+        zeroNeedleAngle: 40,
+        zeroTickAngle: 60,
+        decimals: 2,
+        format: 'short',
+        operatorName: 'avg',
+      },
+      thresholds: '50,80',
+      colors: ['green', 'yellow', 'red'],
+      tickMaps: [
+        { value: '100', text: 'Low' },
+        { value: '300', text: 'Mid' },
+      ],
+      operatorName: 'avg',
+      markerEndEnabled: true,
+      markerEndShape: 'arrow',
+      markerStartEnabled: false,
+      markerStartShape: 'circle',
+    } as any;
+
+    const result = PanelMigrationHandler(panel);
+
+    // Verify limits migrated
+    expect(result.maxValue).toBe(500);
+    // Verify operator converted
+    expect(result.operatorName).toBe('mean');
+    // Verify tick maps migrated
+    expect(result.tickMapConfig?.tickMaps).toHaveLength(2);
+    expect(result.tickMapConfig?.tickMaps[0].text).toBe('Low');
+    // Verify thresholds migrated to fieldConfig
+    expect(panel.fieldConfig.defaults.thresholds).toBeDefined();
+    expect(panel.fieldConfig.defaults.thresholds.mode).toBe(ThresholdsMode.Absolute);
+    expect(panel.fieldConfig.defaults.thresholds.steps).toHaveLength(3);
+    expect(panel.fieldConfig.defaults.thresholds.steps[1].value).toBe(50);
+    expect(panel.fieldConfig.defaults.thresholds.steps[2].value).toBe(80);
+    // Verify colors used for thresholds
+    expect(panel.fieldConfig.defaults.thresholds.steps[0].color).toBe('green');
+    expect(panel.fieldConfig.defaults.thresholds.steps[1].color).toBe('yellow');
+    expect(panel.fieldConfig.defaults.thresholds.steps[2].color).toBe('red');
+    // Verify markers
+    expect(result.markerEndEnabled).toBe(true);
+    expect(result.markerEndShape).toBe('arrow');
+    expect(result.markerStartEnabled).toBe(false);
+    expect(result.markerStartShape).toBe('circle');
+    // Verify angular properties cleaned up
+    expect(panel.gauge).toBeUndefined();
+    expect(panel.thresholds).toBeUndefined();
+    expect(panel.colors).toBeUndefined();
+    expect(panel.tickMaps).toBeUndefined();
+    expect(panel.operatorName).toBeUndefined();
+  });
+
+  it('uses default threshold colors when none provided', () => {
+    const panel = {
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      gauge: {
+        minValue: 0,
+        maxValue: 100,
+        tickSpaceMinVal: 0,
+        tickSpaceMajVal: 0,
+        gaugeUnits: '',
+        gaugeRadius: 0,
+        pivotRadius: 0,
+        padding: 0,
+        edgeWidth: 0,
+        tickEdgeGap: 0,
+        tickLengthMaj: 0,
+        tickLengthMin: 0,
+        needleTickGap: 0,
+        needleLengthNeg: 0,
+        ticknessGaugeBasis: 0,
+        needleWidth: 0,
+        outerEdgeCol: '',
+        innerCol: '',
+        pivotCol: '',
+        tickColMaj: '',
+        tickColMin: '',
+        tickLabelCol: '',
+        unitsLabelCol: '',
+        show: false,
+        showLowerThresholdRange: false,
+        showMiddleThresholdRange: false,
+        showUpperThresholdRange: false,
+        showThresholdColorOnBackground: false,
+        showThresholdColorOnValue: false,
+        showThresholdOnGauge: false,
+        thresholdColors: [],
+        tickFont: '',
+        unitsFont: '',
+        unitsLabelFontSize: 0,
+        labelFontSize: 0,
+        tickWidthMaj: 0,
+        tickWidthMin: 0,
+        zeroNeedleAngle: 0,
+        zeroTickAngle: 0,
+        decimals: 0,
+        format: '',
+        operatorName: '',
+      },
+      thresholds: '20,60',
+      colors: [],
+    } as any;
+
+    PanelMigrationHandler(panel);
+    const steps = panel.fieldConfig.defaults.thresholds.steps;
+    // Default colors should be used
+    expect(steps[0].color).toBe('rgba(50, 172, 45, 0.97)');
+    expect(steps[1].color).toBe('rgba(237, 129, 40, 0.89)');
+    expect(steps[2].color).toBe('rgba(245, 54, 54, 0.9)');
+  });
+
+  it('skips threshold migration when threshold string is empty', () => {
+    const panel = {
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      gauge: {
+        minValue: 0,
+        maxValue: 100,
+        tickSpaceMinVal: 0,
+        tickSpaceMajVal: 0,
+        gaugeUnits: '',
+        gaugeRadius: 0,
+        pivotRadius: 0,
+        padding: 0,
+        edgeWidth: 0,
+        tickEdgeGap: 0,
+        tickLengthMaj: 0,
+        tickLengthMin: 0,
+        needleTickGap: 0,
+        needleLengthNeg: 0,
+        ticknessGaugeBasis: 0,
+        needleWidth: 0,
+        outerEdgeCol: '',
+        innerCol: '',
+        pivotCol: '',
+        tickColMaj: '',
+        tickColMin: '',
+        tickLabelCol: '',
+        unitsLabelCol: '',
+        show: false,
+        showLowerThresholdRange: false,
+        showMiddleThresholdRange: false,
+        showUpperThresholdRange: false,
+        showThresholdColorOnBackground: false,
+        showThresholdColorOnValue: false,
+        showThresholdOnGauge: false,
+        thresholdColors: [],
+        tickFont: '',
+        unitsFont: '',
+        unitsLabelFontSize: 0,
+        labelFontSize: 0,
+        tickWidthMaj: 0,
+        tickWidthMin: 0,
+        zeroNeedleAngle: 0,
+        zeroTickAngle: 0,
+        decimals: 0,
+        format: '',
+        operatorName: '',
+      },
+      thresholds: '',
+    } as any;
+
+    PanelMigrationHandler(panel);
+    // Empty string is falsy, so thresholds are not migrated
+    expect(panel.fieldConfig.defaults.thresholds).toBeUndefined();
+  });
+
+  it('migrates format to unitFormat on options', () => {
+    const panel = {
+      id: 0,
+      type: 'panel',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      gauge: {
+        minValue: 0,
+        maxValue: 100,
+        tickSpaceMinVal: 0,
+        tickSpaceMajVal: 0,
+        gaugeUnits: '',
+        gaugeRadius: 0,
+        pivotRadius: 0,
+        padding: 0,
+        edgeWidth: 0,
+        tickEdgeGap: 0,
+        tickLengthMaj: 0,
+        tickLengthMin: 0,
+        needleTickGap: 0,
+        needleLengthNeg: 0,
+        ticknessGaugeBasis: 0,
+        needleWidth: 0,
+        outerEdgeCol: '',
+        innerCol: '',
+        pivotCol: '',
+        tickColMaj: '',
+        tickColMin: '',
+        tickLabelCol: '',
+        unitsLabelCol: '',
+        show: false,
+        showLowerThresholdRange: false,
+        showMiddleThresholdRange: false,
+        showUpperThresholdRange: false,
+        showThresholdColorOnBackground: false,
+        showThresholdColorOnValue: false,
+        showThresholdOnGauge: false,
+        thresholdColors: [],
+        tickFont: '',
+        unitsFont: '',
+        unitsLabelFontSize: 0,
+        labelFontSize: 0,
+        tickWidthMaj: 0,
+        tickWidthMin: 0,
+        zeroNeedleAngle: 0,
+        zeroTickAngle: 0,
+        decimals: 0,
+        format: '',
+        operatorName: '',
+      },
+      format: 'bytes',
+    } as any;
+
+    const result = PanelMigrationHandler(panel);
+    expect((result as Record<string, unknown>).unitFormat).toBe('bytes');
+    expect(panel.format).toBeUndefined();
   });
 });

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -9,7 +9,7 @@ import {
 import { config } from '@grafana/runtime';
 import { satisfies, coerce } from 'semver';
 
-import { FontFamilies, GaugeOptions, GaugePresetOptions, Markers } from './components/types';
+import { FontFamilies, GaugeOptions, Markers } from './components/types';
 import { TickMapItemType } from 'components/TickMaps/types';
 
 interface AngularTickMap {
@@ -505,24 +505,6 @@ const migrateThresholds = (thresholds: string, thresholdColors: string[]) => {
   return migratedThresholds;
 };
 
-/**
- * This is called when the panel changes from another panel
- *
- * not currently used
- */
-export const PanelChangedHandler = (
-  panel: PanelModel<Partial<GaugeOptions>> | any,
-  prevPluginId: string,
-  prevOptions: any
-) => {
-  // Changing from angular d3gauge panel
-  if (prevPluginId === 'd3gauge' && prevOptions.angular) {
-    // console.log('detected old panel');
-    const oldOpts = prevOptions.angular;
-    // console.log(JSON.stringify(oldOpts));
-  }
-  return {};
-};
 
 // Roboto font was removed Dec 1, 2022, and releases after that date should not attempt to use it
 export const hasRobotoFont = () => {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -103,8 +103,8 @@ interface AngularPanelProperties {
   svgContainer?: unknown;
   unitFormats?: unknown;
   mappingType?: number;
-  valueMaps?: Array<unknown>;
-  rangeMaps?: Array<unknown>;
+  valueMaps?: unknown[];
+  rangeMaps?: unknown[];
   mappingTypes?: unknown;
   [key: string]: unknown;
 }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -81,104 +81,108 @@ interface AngularOptions {
   operatorName: string;
 }
 
+/** Panel-level properties present during Angular-to-React migration. */
+interface AngularPanelProperties {
+  gauge?: AngularOptions;
+  format?: string;
+  decimals?: number;
+  thresholds?: string;
+  colors?: string[];
+  tickMaps?: AngularTickMap[];
+  operatorName?: string;
+  operatorNameOptions?: unknown;
+  fontSizes?: unknown;
+  fontTypes?: unknown;
+  gaugeDivId?: unknown;
+  markerEndEnabled?: boolean;
+  markerEndShape?: string;
+  markerStartEnabled?: boolean;
+  markerStartShape?: string;
+  markerEndShapes?: unknown;
+  markerStartShapes?: unknown;
+  svgContainer?: unknown;
+  unitFormats?: unknown;
+  mappingType?: number;
+  valueMaps?: Array<unknown>;
+  rangeMaps?: Array<unknown>;
+  mappingTypes?: unknown;
+  [key: string]: unknown;
+}
+
+type AngularPanel = PanelModel<GaugeOptions> & AngularPanelProperties;
+
+/** FieldConfig with extra top-level properties from angular migration. */
+interface AngularFieldConfig extends FieldConfigSource {
+  decimals?: number;
+  unit?: string;
+}
+
 /**
  * This is called when the panel is imported or reloaded
  */
 export const PanelMigrationHandler = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
-  // @ts-ignore
-  if (!panel.gauge) {
+  const ap = panel as AngularPanel;
+  if (!ap.gauge) {
     // not angular, just return the options if currently set
     if (!panel.options) {
       // This happens on the first load or when migrating from angular
-      return {} as any;
+      return {};
     }
     // have settings, return them unchanged
     return panel.options;
   }
-  // @ts-ignore
-  const newDefaults = migrateDefaults(panel.gauge);
+  const newDefaults = migrateDefaults(ap.gauge);
   const options = newDefaults;
   // using fieldConfig
-  // @ts-ignore
-  panel.fieldConfig = migrateFieldConfig(panel, panel.fieldConfig);
-  // @ts-ignore
-  if (panel.format) {
-    // @ts-ignore
-    options.unitFormat = panel.format;
-    // @ts-ignore
-    delete panel.format;
+  ap.fieldConfig = migrateFieldConfig(ap, ap.fieldConfig as AngularFieldConfig);
+  if (ap.format) {
+    (options as unknown as Record<string, unknown>).unitFormat = ap.format;
+    delete ap.format;
   }
-  // @ts-ignore
-  if (panel.decimals) {
-    // @ts-ignore
-    options.decimals = panel.decimals;
-    // @ts-ignore
-    delete panel.decimals;
+  if (ap.decimals) {
+    (options as unknown as Record<string, unknown>).decimals = ap.decimals;
+    delete ap.decimals;
   }
-  // @ts-ignore
-  if (panel.thresholds) {
-    // @ts-ignore
-    const migratedThresholds = migrateThresholds(panel.thresholds, panel.colors);
-    panel.fieldConfig.defaults.thresholds = migratedThresholds;
+  if (ap.thresholds) {
+    const migratedThresholds = migrateThresholds(ap.thresholds, ap.colors || []);
+    ap.fieldConfig.defaults.thresholds = migratedThresholds;
   }
-  // @ts-ignore
-  delete panel.colors;
-  // @ts-ignore
-  delete panel.thresholds;
-  // @ts-ignore
-  options.tickMapConfig = migrateTickMaps(panel.tickMaps) || [];
-  // @ts-ignore
-  delete panel.tickMaps;
+  delete ap.colors;
+  delete ap.thresholds;
+  options.tickMapConfig = migrateTickMaps(ap.tickMaps || []);
+  delete ap.tickMaps;
   // migrate mappingTypes/Value/RangeMaps
-  const newMaps = migrateValueAndRangeMaps(panel);
-  panel.fieldConfig.defaults.mappings = newMaps;
-  // @ts-ignore
-  delete panel.mappingType;
-  // @ts-ignore
-  delete panel.mappingTypes;
-  // @ts-ignore
-  delete panel.rangeMaps;
-  // @ts-ignore
-  delete panel.valueMaps;
+  const newMaps = migrateValueAndRangeMaps(ap);
+  ap.fieldConfig.defaults.mappings = newMaps;
+  delete ap.mappingType;
+  delete ap.mappingTypes;
+  delete ap.rangeMaps;
+  delete ap.valueMaps;
   // operator conversion
-  // @ts-ignore
-  options.operatorName = convertOperators(panel.operatorName);
-  // @ts-ignore
-  delete panel.operatorName;
-  // @ts-ignore
-  delete panel.operatorNameOptions;
+  options.operatorName = convertOperators(ap.operatorName || '');
+  delete ap.operatorName;
+  delete ap.operatorNameOptions;
   // general clean up
-  // @ts-ignore
-  delete panel.fontSizes;
-  // @ts-ignore
-  delete panel.fontTypes;
-  // @ts-ignore
-  delete panel.gaugeDivId;
-  // @ts-ignore
-  options.markerEndEnabled = panel.markerEndEnabled;
-  // @ts-ignore
-  options.markerEndShape = Markers.find((e) => e.name === panel.markerEndShape) || Markers[0];
-  // @ts-ignore
-  delete panel.markerEndShapes;
-  // @ts-ignore
-  options.markerStartEnabled = panel.markerStartEnabled;
-  // @ts-ignore
-  options.markerStartShape = Markers.find((e) => e.name === panel.markerStartShape) || Markers[1];
-  // @ts-ignore
-  delete panel.markerStartShapes;
-  // @ts-ignore
-  delete panel.operatorNameOptions;
-  // @ts-ignore
-  delete panel.svgContainer;
-  // @ts-ignore
-  delete panel.unitFormats;
-  // @ts-ignore
-  delete panel.gauge;
+  delete ap.fontSizes;
+  delete ap.fontTypes;
+  delete ap.gaugeDivId;
+  options.markerEndEnabled = ap.markerEndEnabled ?? false;
+  options.markerEndShape = (Markers.find((e) => e.name === ap.markerEndShape) || Markers[0]).name;
+  delete ap.markerEndShapes;
+  options.markerStartEnabled = ap.markerStartEnabled ?? false;
+  options.markerStartShape = (Markers.find((e) => e.name === ap.markerStartShape) || Markers[1]).name;
+  delete ap.markerStartShapes;
+  delete ap.operatorNameOptions;
+  delete ap.svgContainer;
+  delete ap.unitFormats;
+  delete ap.gauge;
   // clean up undefined
-  // @ts-ignore
-  Object.keys(panel).forEach((key) => (panel[key] === undefined ? delete panel[key] : {}));
-  // @ts-ignore
-  Object.keys(options).forEach((key) => (options[key] === undefined ? delete options[key] : {}));
+  Object.keys(ap).forEach((key) => (ap[key] === undefined ? delete ap[key] : {}));
+  Object.keys(options).forEach((key) => {
+    if ((options as unknown as Record<string, unknown>)[key] === undefined) {
+      delete (options as unknown as Record<string, unknown>)[key];
+    }
+  });
 
   return options;
 };
@@ -203,6 +207,7 @@ export const migrateTickMaps = (tickMaps: AngularTickMap[]) => {
   if (!tickMaps || tickMaps.length === 0) {
     return {
       tickMaps: newTickMaps,
+      enabled: true,
     };
   }
   let count = 0;
@@ -219,30 +224,25 @@ export const migrateTickMaps = (tickMaps: AngularTickMap[]) => {
   }
   return {
     tickMaps: newTickMaps,
+    enabled: true,
   };
 };
 
-export const migrateFieldConfig = (panel: PanelModel<GaugeOptions, any>, fieldConfig: FieldConfigSource<any>) => {
-  // @ts-ignore
+export const migrateFieldConfig = (panel: AngularPanel, fieldConfig: AngularFieldConfig) => {
   if (panel.decimals) {
-    // @ts-ignore
     fieldConfig.decimals = panel.decimals;
-    // @ts-ignore
     delete panel.decimals;
   }
   // units
-  // @ts-ignore
   if (panel.gauge) {
-    // @ts-ignore
     if (panel.gauge.gaugeUnits) {
-      // @ts-ignore
       fieldConfig.unit = panel.gauge.gaugeUnits;
     }
   }
   return fieldConfig;
 };
 
-export const migrateValueAndRangeMaps = (panel: any) => {
+export const migrateValueAndRangeMaps = (panel: AngularPanel) => {
   // value maps first
   panel.mappingType = 1;
   let newValueMappings: ValueMapping[] = [];

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,6 @@ import {
   FontFamilyOptions,
   FontSizes,
   GaugeOptions,
-  GaugePresetOptions,
   MarkerOptions,
   OperatorOptions,
 } from 'components/types';
@@ -123,23 +122,6 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         },
       })
 
-      // Presets
-      /*
-      .addSelect({
-        name: 'Preset',
-        path: 'presetIndex',
-        description: 'Modify current gauge with preset values',
-        settings: {
-          options: [
-            { value: GaugePresetOptions[0].id, label: GaugePresetOptions[0].name },
-            { value: GaugePresetOptions[1].id, label: GaugePresetOptions[1].name },
-            { value: GaugePresetOptions[2].id, label: GaugePresetOptions[2].name },
-          ],
-        },
-        defaultValue: GaugePresetOptions[0].id,
-        category: ['Presets'],
-      })
-      */
       // animateNeedleValueTransition
       .addBooleanSwitch({
         name: 'Animate Needle Transition',


### PR DESCRIPTION
## Summary

- Fix `for...in` bug in `renderMajorTickLabels` iterating array indices instead of values, causing incorrect font scaling
- Fix falsy-zero bugs where `displayValue` of `0` skipped threshold coloring in `renderCircleGroup`, `valueColor`, and `titleColor` (strict `!== null` check matching `number | null` type)
- Add React `key` props to threshold band elements
- Fix `migrateTickMaps` missing `enabled` field and marker shape migration assigning `MarkerType` object to `string` field

## Type Safety

- Replace all `any` types (`dToR`, `panelHeight`/`panelWidth`, `migrateValueAndRangeMaps` param)
- Add `AngularPanelProperties`, `AngularPanel`, and `AngularFieldConfig` interfaces, eliminating all 38 `@ts-ignore` suppressions in migration code

## Lint

- Fix `Array<unknown>` → `unknown[]` shorthand syntax in migration interfaces

## Cleanup

- Remove dead code: unused `GaugeModel` interface, commented-out `MarkerStartShapes`/`MarkerEndShapes`, unused `GaugePresetOptions`/`GaugePresetType` exports, `PanelChangedHandler`, unused `React` import in `needle_utils.tsx`, unexposed `needleLengthNegCalc`

## Testing

- Add 34 migration tests covering `convertOperators`, `migrateTickMaps`, `migrateFieldConfig`, `migrateValueAndRangeMaps`, `migrateDefaults`, and full `PanelMigrationHandler` integration
- Migration tests: 4 → 38, total suite: 200 → 234

## Docs

- Fix `TickMapItem` → `TickMapItemType` in AGENTS.md naming conventions
- Add Angular migration interface names to migrations.ts description

## Test plan

- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm exec jest` passes (234 tests, 12 suites)
- [x] `pnpm build` succeeds
- [x] `pnpm spellcheck` passes (0 issues)
- [x] `npx markdownlint-cli2 AGENTS.md CHANGELOG.md` passes