### PR TITLE
fix: prevent browser hang with large gauge max values (#63)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,10 @@ pnpm exec jest --testNamePattern="Min Needle"
 |                          | thresholds) and `scaleLabelFontSize`                       |
 | `useNeedleAnimation.ts`  | Custom hook: D3 needle animation with ref-based tracking,  |
 |                          | cross-limit clamping, and buried-needle skip logic         |
-| `useTickComputations.ts` | Custom hook: tick spacing, angle, and label computation    |
+| `useTickComputations.ts` | Custom hook: tick spacing, angle, label computation, and   |
+|                          | `ticksClamped` flag (MAX_TICKS = 100 with iteration guard) |
+| `tick_spacing.ts`        | `computeTickSpacing` utility: nice-number tick intervals   |
+|                          | using 1-2-5 series for any value range                     |
 | `useGaugeDimensions.ts`  | Custom hook: SVG geometry, edge radii, tick/needle lengths |
 | `needle_utils.tsx`       | Needle angle math for the "crossing limits" feature;       |
 |                          | uses `maxNeedleAngle` (not `maxTickAngle`) for clamping    |
@@ -74,10 +77,12 @@ pnpm exec jest --testNamePattern="Min Needle"
 
 ### Other Key Files
 
-| File                       | Purpose                                                 |
-| -------------------------- | ------------------------------------------------------- |
-| `src/components/types.ts`  | `GaugeOptions` interface and all other TypeScript types |
-| `src/components/TickMaps/` | Custom editor UI for tick value mappings                |
+| File                           | Purpose                                                     |
+| ------------------------------ | ----------------------------------------------------------- |
+| `src/components/types.ts`      | `GaugeOptions` interface and all other TypeScript types     |
+| `src/components/TickMaps/`     | Custom editor UI for tick value mappings                    |
+| `src/components/editors/`      | Custom panel option editors (`RangeEditor` for min/max with |
+|                                | auto tick spacing when ticks would exceed limit)            |
 
 ### Build & Config
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ pnpm exec jest --testNamePattern="Min Needle"
   Outputs AMD format. SWC transpiles to ES2015. Grafana runtime libs are externals.
 - **tsconfig.json** extends `.config/tsconfig.json`, with `noUnusedLocals` disabled.
 - **ESLint** extends Grafana's base rules (see Code Style for details).
-- **Jest** uses SWC transformer, jsdom environment, and `jest-setup.js` which sets `TZ=UTC` for snapshot consistency.
+- **Jest** uses SWC transformer, jsdom environment, and `jest-setup.js` which
+  filters jsdom SVG tag warnings and i18next promotional banners from test output.
 - CSS modules are mocked with `identity-obj-proxy` in tests.
 
 ## CI/CD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All changes noted here.
 - Fix `migrateTickMaps` missing `enabled` field in return value
 - Fix marker shape migration assigning `MarkerType` object to `string`
   field (now correctly extracts `.name`)
+- Fix browser hang when gauge max value is very large (e.g., 6 billion)
+  by lowering tick cap from 500 to 100, adding an iteration guard to
+  prevent runaway loops, and auto-calculating tick spacing when the
+  user changes min/max values (fixes #63)
 
 ### Type Safety
 
@@ -67,6 +71,14 @@ All changes noted here.
 - Bump `actions/github-script` v8.0.0 → v9.0.0
 - Remove `master` branch references, pin actions to version tags
 - Clean up scaffolding comments in release.yml
+
+### New Features
+
+- Add `computeTickSpacing` utility that calculates human-friendly
+  ("nice number") tick intervals for any value range
+- Auto-fill tick spacing when min/max values change in the panel editor
+- Show warning icon with tooltip when tick count is clamped, including
+  suggested spacing values
 
 ### E2E Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,15 @@ All changes noted here.
 
 - Add `computeTickSpacing` utility that calculates human-friendly
   ("nice number") tick intervals for any value range
-- Auto-fill tick spacing when min/max values change in the panel editor
+- Auto-fill tick spacing when min/max values change in the panel editor,
+  only when the new range would exceed the 100-tick limit (preserves
+  user-configured spacing otherwise)
 - Show warning icon with tooltip when tick count is clamped, including
   suggested spacing values
+- Use `@grafana/ui` `Input` component in `RangeEditor` for theme
+  consistency
+- Sync `RangeEditor` local state when external value prop changes
+  (undo/reset)
 
 ### E2E Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ All changes noted here.
 - Sync `RangeEditor` local state when external value prop changes
   (undo/reset)
 
+### Panel Editor UX
+
+- Rename "Show title" to "Show Display Name on Gauge" and move above
+  Stat in Standard options
+- Rename "Title Font/Size" to "Display Name Font/Size"
+- Rename "Title Y-Offset" to "Display Name Y-Offset (Vertical)"
+- Rename "Value Y-Offset" to "Value Y-Offset (Vertical)"
+- Reorder font settings: Display Name, Value, Tick Label
+- Add inline description to Tick Maps editor section
+- Fix `needleCrossLimitDegrees` default (10 → 5) to match description
+- Increase vertical spacing between display name and value labels
+
 ### Testing Infrastructure
 
 - Suppress jsdom SVG tag warnings (`<path>`, `<marker>`, `<defs>`) in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ All changes noted here.
 - Sync `RangeEditor` local state when external value prop changes
   (undo/reset)
 
+### Testing Infrastructure
+
+- Suppress jsdom SVG tag warnings (`<path>`, `<marker>`, `<defs>`) in
+  test output via `jest-setup.js` console filter
+- Suppress i18next promotional banner in test output
+
 ### E2E Testing
 
 - Add Playwright config with `@grafana/plugin-e2e` auth and Chromium project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All changes noted here.
   by lowering tick cap from 500 to 100, adding an iteration guard to
   prevent runaway loops, and auto-calculating tick spacing when the
   user changes min/max values (fixes #63)
+- Fix threshold band angular misalignment with gauge ticks when using
+  non-default `zeroTickAngle`/`maxTickAngle` values; the `drawBand`
+  rotation is now computed as `2 * zeroTickAngle + 180` instead of
+  being hardcoded to `maxTickAngle`
 
 ### Type Safety
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ and allows the needle to cross the limit (burying the needle).
 | Minimum Value | Minimum Value allowed on the face |
 | Maximum Value | Maximum Value allowed on the face |
 
+When you change the Minimum or Maximum Value, tick spacing is
+automatically recalculated if the new range would produce more than
+100 ticks. If the current tick spacing is still within the limit,
+your settings are preserved. A warning icon appears on the gauge
+when the tick count is clamped, with a tooltip showing suggested
+spacing values.
+
 #### Coloring
 
 ![Coloring](https://raw.githubusercontent.com/briangann/grafana-gauge-panel/main/src/screenshots/react-config-coloring.png)

--- a/README.md
+++ b/README.md
@@ -36,24 +36,25 @@ The React port has separated the configuration options into multiple searchable 
 
 ![Standard Options](https://raw.githubusercontent.com/briangann/grafana-gauge-panel/main/src/screenshots/react-config-standard-options.png)
 
-| Option   | Description                                                               |
-| -------- | ------------------------------------------------------------------------- |
-| Stat     | The statistic to be displayed on the gauge                                |
-| Unit     | A unit for the value displayed. This will be used to abbreviate as needed |
-| Decimals | Maximum number of decimals to display if any are required                 |
+| Option                       | Description                                                               |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| Show Display Name on Gauge   | Show the field or series name above the value on the gauge                |
+| Stat                         | The statistic to be displayed on the gauge                                |
+| Unit                         | A unit for the value displayed. This will be used to abbreviate as needed |
+| Decimals                     | Maximum number of decimals to display if any are required                 |
 
 #### Font Settings
 
 ![Font Settings](https://raw.githubusercontent.com/briangann/grafana-gauge-panel/main/src/screenshots/react-config-font-settings.png)
 
-| Option               | Description                                 |
-| -------------------- | ------------------------------------------- |
-| Value Font           | Font to be used on the value displayed      |
-| Value Font Size      | Font Size for the value displayed           |
-| Title Font           | Font to be used on the title displayed      |
-| Title Font Size      | Font Size for the title displayed           |
-| Tick Label Font      | Font to be used on the tick labels          |
-| Tick Label Font Size | Font size to be used for the tick labels    |
+| Option                  | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| Display Name Font       | Font used for the display name shown above the value |
+| Display Name Font Size  | Font size of the display name                        |
+| Value Font              | Font to be used on the value displayed               |
+| Value Font Size         | Font size for the value displayed                    |
+| Tick Label Font         | Font to be used on the tick labels                   |
+| Tick Label Font Size    | Font size to be used for the tick labels             |
 
 #### Needle Options
 
@@ -113,21 +114,22 @@ Adjust in small increments to see how they affect the gauge.
 
 ![Radial Customization](https://raw.githubusercontent.com/briangann/grafana-gauge-panel/main/src/screenshots/react-radial-customization.png)
 
-| Option               | Description                                                                 |
-| -------------------- | --------------------------------------------------------------------------- |
-| Radius               | Specifies size of gauge by radius. Value 0 will auto-scale to fit panel     |
-| Tickness Gauge Basis | Scaling for tick, a lower value will autoscale poorly                       |
-| Pivot Radius         | Size of the center pivot, as a percentage of radius                         |
-| Value Y-Offset       | Sets a vertical offset to better place the displayed metric                 |
-| Padding              | Adds space between the ticks and outer edge                                 |
-| Edge Width           | Thickness of the circle around the edge, as a percentage of gauge radius    |
-| Tick Edge Gap        | Spacing between ticks and the outer circle, as a percentage of gauge radius |
-| Tick Length Major    | Length of the major ticks, as a percentage of the gauge radius              |
-| Tick Width Major     | Width of the major ticks in pixels                                          |
-| Tick Length Minor    | Length of the minor ticks, as a percentage of the gauge radius              |
-| Tick Width Minor     | Width of the minor ticks in pixels                                          |
-| Needle Tick Gap      | Spacing between ticks and the needle end, as a percentage of gauge radius   |
-| Needle Length Stem   | Length of the needle beyond the centre, as a percentage of gauge radius     |
+| Option                            | Description                                                             |
+| --------------------------------- | ----------------------------------------------------------------------- |
+| Radius                            | Specifies size of gauge by radius. Value 0 will auto-scale to fit panel |
+| Tickness Gauge Basis              | Scaling for tick, a lower value will autoscale poorly                   |
+| Pivot Radius                      | Size of the center pivot, as a percentage of radius                     |
+| Value Y-Offset (Vertical)         | Sets a vertical offset to better place the displayed metric             |
+| Display Name Y-Offset (Vertical)  | Sets a vertical offset to better place the display name                 |
+| Padding                           | Adds space between the ticks and outer edge                             |
+| Edge Width                        | Thickness of the circle around the edge, as a percentage of radius      |
+| Tick Edge Gap                     | Spacing between ticks and the outer circle, as a percentage of radius   |
+| Tick Length Major                 | Length of the major ticks, as a percentage of the gauge radius          |
+| Tick Width Major                  | Width of the major ticks in pixels                                      |
+| Tick Length Minor                 | Length of the minor ticks, as a percentage of the gauge radius          |
+| Tick Width Minor                  | Width of the minor ticks in pixels                                      |
+| Needle Tick Gap                   | Spacing between ticks and needle end, as a percentage of gauge radius   |
+| Needle Length Stem                | Length of the needle beyond the centre, as a percentage of gauge radius |
 
 #### Gauge Degrees
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -10,3 +10,12 @@ console.error = (...args) => {
   }
   originalConsoleError(...args);
 };
+
+// Suppress i18next promotional banner from Grafana UI internals.
+const originalConsoleInfo = console.info;
+console.info = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('i18next')) {
+    return;
+  }
+  originalConsoleInfo(...args);
+};

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -2,7 +2,7 @@
 import './.config/jest-setup';
 
 // Suppress React warnings about SVG tags (path, marker, defs, etc.)
-// that jsdom does not recognise as valid HTML elements.
+// that jsdom does not recognize as valid HTML elements.
 const originalConsoleError = console.error;
 console.error = (...args) => {
   if (typeof args[0] === 'string' && args[0].includes('is unrecognized in this browser')) {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,2 +1,12 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
+
+// Suppress React warnings about SVG tags (path, marker, defs, etc.)
+// that jsdom does not recognise as valid HTML elements.
+const originalConsoleError = console.error;
+console.error = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('is unrecognized in this browser')) {
+    return;
+  }
+  originalConsoleError(...args);
+};

--- a/src/components/Gauge/Gauge.test.tsx
+++ b/src/components/Gauge/Gauge.test.tsx
@@ -291,4 +291,24 @@ describe('Gauge', () => {
       expect(svg?.getAttribute('viewBox')).toBe('0,0,200,200');
     });
   });
+
+  describe('tick clamp warning', () => {
+    it('does not render warning icon for normal tick configs', () => {
+      const onTicksClamped = jest.fn();
+      render(<Gauge {...defaultOptions} onTicksClamped={onTicksClamped} />);
+      expect(onTicksClamped).toHaveBeenCalledWith(false);
+    });
+
+    it('reports ticksClamped true when ticks exceed limit', () => {
+      const onTicksClamped = jest.fn();
+      render(
+        <Gauge
+          {...defaultOptions}
+          tickSpacingMajor={0.001}
+          onTicksClamped={onTicksClamped}
+        />
+      );
+      expect(onTicksClamped).toHaveBeenCalledWith(true);
+    });
+  });
 });

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -138,11 +138,21 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
   );
 
   const { valueFontSize, titleFontSize, valueLabelY, titleLabelY } = useMemo(() => {
-    const vfs = scaleLabelFontSize(options.valueFontSize, options.gaugeRadius, options.ticknessGaugeBasis);
-    const tfs = scaleLabelFontSize(options.titleFontSize, options.gaugeRadius, options.ticknessGaugeBasis);
-    const vly = labelYCalc(0, vfs, labelStart, originY) + options.valueYOffset;
-    const tly = labelYCalc(0, tfs, labelStart, originY) + options.titleYOffset - vfs / 2 - tfs / 2;
-    return { valueFontSize: vfs, titleFontSize: tfs, valueLabelY: vly, titleLabelY: tly };
+    const scaledValueFontSize = scaleLabelFontSize(options.valueFontSize, options.gaugeRadius, options.ticknessGaugeBasis);
+    const scaledTitleFontSize = scaleLabelFontSize(options.titleFontSize, options.gaugeRadius, options.ticknessGaugeBasis);
+    const valueLabelYPos = labelYCalc(0, scaledValueFontSize, labelStart, originY) + options.valueYOffset;
+    const titleLabelYPos =
+      labelYCalc(0, scaledTitleFontSize, labelStart, originY) +
+      options.titleYOffset -
+      scaledValueFontSize / 2 -
+      scaledTitleFontSize / 2 -
+      scaledTitleFontSize * 0.3;
+    return {
+      valueFontSize: scaledValueFontSize,
+      titleFontSize: scaledTitleFontSize,
+      valueLabelY: valueLabelYPos,
+      titleLabelY: titleLabelYPos,
+    };
   }, [
     options.valueFontSize,
     options.titleFontSize,

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useMemo } from 'react';
+import React, { useEffect, useId, useMemo } from 'react';
 
 import { scaleLinear } from 'd3';
 
@@ -64,7 +64,7 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
       .range([options.zeroTickAngle, options.maxTickAngle]);
   }, [options.minValue, options.maxValue, options.zeroTickAngle, options.maxTickAngle]);
 
-  const { tickAnglesMaj, tickAnglesMin, tickMajorLabels, tickPathsMaj, tickPathsMin } = useTickComputations({
+  const { tickAnglesMaj, tickAnglesMin, tickMajorLabels, tickPathsMaj, tickPathsMin, ticksClamped } = useTickComputations({
     minValue: options.minValue,
     maxValue: options.maxValue,
     zeroTickAngle: options.zeroTickAngle,
@@ -80,6 +80,10 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
     tickLengthMaj: options.tickLengthMaj,
     tickLengthMin: options.tickLengthMin,
   });
+
+  useEffect(() => {
+    options.onTicksClamped?.(ticksClamped);
+  }, [ticksClamped, options.onTicksClamped]);
 
   useNeedleAnimation(needleId, {
     displayValue: options.displayValue ?? NaN,

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -23,6 +23,7 @@ import { useTickComputations } from './useTickComputations';
 import { useNeedleAnimation } from './useNeedleAnimation';
 
 export const Gauge: React.FC<GaugeOptions> = (options) => {
+  const { onTicksClamped } = options;
   const divStyles = useStyles2(getWrapperStyles);
   const svgStyles = useStyles2(getSVGStyles);
   const needleId = useId();
@@ -82,8 +83,8 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
   });
 
   useEffect(() => {
-    options.onTicksClamped?.(ticksClamped);
-  }, [ticksClamped, options.onTicksClamped]);
+    onTicksClamped?.(ticksClamped);
+  }, [ticksClamped, onTicksClamped]);
 
   useNeedleAnimation(needleId, {
     displayValue: options.displayValue ?? NaN,

--- a/src/components/Gauge/tick_spacing.test.ts
+++ b/src/components/Gauge/tick_spacing.test.ts
@@ -1,0 +1,101 @@
+import { computeTickSpacing } from './tick_spacing';
+
+describe('computeTickSpacing', () => {
+  describe('nice number rounding', () => {
+    it('returns exact spacing when range divides evenly', () => {
+      const result = computeTickSpacing(0, 100);
+      expect(result.majorSpacing).toBe(10);
+      expect(result.minorSpacing).toBe(2);
+    });
+
+    it('rounds to nearest nice number for uneven ranges', () => {
+      const result = computeTickSpacing(0, 255);
+      // 255 / 10 = 25.5, nearest nice number is 20
+      expect(result.majorSpacing).toBe(20);
+      expect(result.minorSpacing).toBe(4);
+    });
+
+    it('handles very large ranges', () => {
+      const result = computeTickSpacing(0, 6_000_000_000);
+      // 6e9 / 10 = 6e8, nearest nice number is 500_000_000
+      expect(result.majorSpacing).toBe(500_000_000);
+      expect(result.minorSpacing).toBe(100_000_000);
+    });
+
+    it('handles ranges in the millions', () => {
+      const result = computeTickSpacing(0, 100_000_000);
+      expect(result.majorSpacing).toBe(10_000_000);
+      expect(result.minorSpacing).toBe(2_000_000);
+    });
+
+    it('handles small fractional ranges', () => {
+      const result = computeTickSpacing(0, 1);
+      // 1 / 10 = 0.1, nice number is 0.1
+      expect(result.majorSpacing).toBe(0.1);
+      expect(result.minorSpacing).toBeCloseTo(0.02);
+    });
+
+    it('handles very small ranges', () => {
+      const result = computeTickSpacing(0, 0.001);
+      expect(result.majorSpacing).toBe(0.0001);
+      expect(result.minorSpacing).toBeCloseTo(0.00002);
+    });
+
+    it('rounds 3.5 interval to 5 (nearest nice number)', () => {
+      // range=35, raw=3.5 -> nice=5
+      const result = computeTickSpacing(0, 35);
+      expect(result.majorSpacing).toBe(5);
+      expect(result.minorSpacing).toBe(1);
+    });
+
+    it('rounds 1.5 interval to 2 (nearest nice number)', () => {
+      // range=15, raw=1.5 -> nice=2
+      const result = computeTickSpacing(0, 15);
+      expect(result.majorSpacing).toBe(2);
+      expect(result.minorSpacing).toBeCloseTo(0.4);
+    });
+  });
+
+  describe('custom target ticks', () => {
+    it('accepts custom targetMajorTicks', () => {
+      const result = computeTickSpacing(0, 100, 5);
+      // 100 / 5 = 20, nice number is 20
+      expect(result.majorSpacing).toBe(20);
+      expect(result.minorSpacing).toBe(4);
+    });
+
+    it('produces fewer ticks with smaller target', () => {
+      const few = computeTickSpacing(0, 100, 3);
+      const many = computeTickSpacing(0, 100, 20);
+      expect(few.majorSpacing).toBeGreaterThan(many.majorSpacing);
+    });
+  });
+
+  describe('non-zero min values', () => {
+    it('handles offset ranges', () => {
+      const result = computeTickSpacing(200, 300);
+      expect(result.majorSpacing).toBe(10);
+      expect(result.minorSpacing).toBe(2);
+    });
+
+    it('handles negative min values', () => {
+      const result = computeTickSpacing(-50, 50);
+      expect(result.majorSpacing).toBe(10);
+      expect(result.minorSpacing).toBe(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns fallback for zero range', () => {
+      const result = computeTickSpacing(100, 100);
+      expect(result.majorSpacing).toBe(1);
+      expect(result.minorSpacing).toBeCloseTo(0.2);
+    });
+
+    it('handles inverted range (min > max)', () => {
+      const result = computeTickSpacing(100, 0);
+      expect(result.majorSpacing).toBe(10);
+      expect(result.minorSpacing).toBe(2);
+    });
+  });
+});

--- a/src/components/Gauge/tick_spacing.ts
+++ b/src/components/Gauge/tick_spacing.ts
@@ -1,0 +1,39 @@
+/**
+ * Rounds a value to the nearest "nice" number in the series
+ * 1, 2, 5, 10, 20, 50, 100, ... (power-of-10 x {1, 2, 5}).
+ */
+const niceNumber = (value: number): number => {
+  const exponent = Math.floor(Math.log10(value));
+  const fraction = value / Math.pow(10, exponent);
+
+  let niceFraction: number;
+  if (fraction < 1.5) {
+    niceFraction = 1;
+  } else if (fraction < 3.5) {
+    niceFraction = 2;
+  } else if (fraction <= 7.5) {
+    niceFraction = 5;
+  } else {
+    niceFraction = 10;
+  }
+
+  return niceFraction * Math.pow(10, exponent);
+};
+
+export const computeTickSpacing = (
+  min: number,
+  max: number,
+  targetMajorTicks = 10
+): { majorSpacing: number; minorSpacing: number } => {
+  const range = Math.abs(max - min);
+
+  if (range === 0 || !isFinite(range)) {
+    return { majorSpacing: 1, minorSpacing: 0.2 };
+  }
+
+  const rawInterval = range / targetMajorTicks;
+  const majorSpacing = niceNumber(rawInterval);
+  const minorSpacing = majorSpacing / 5;
+
+  return { majorSpacing, minorSpacing };
+};

--- a/src/components/Gauge/useTickComputations.test.ts
+++ b/src/components/Gauge/useTickComputations.test.ts
@@ -254,7 +254,7 @@ describe('useTickComputations', () => {
       expect(result.current.tickAnglesMaj.length).toBeGreaterThan(0);
     });
 
-    it('caps tick count at 500', () => {
+    it('caps tick count at 100', () => {
       const { result } = renderHook(() =>
         useTickComputations({
           ...defaultOpts,
@@ -262,7 +262,51 @@ describe('useTickComputations', () => {
           valueScale: makeScale(0, 100, 60, 300),
         })
       );
-      expect(result.current.tickAnglesMin.length).toBeLessThanOrEqual(500);
+      expect(result.current.tickAnglesMin.length).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('ticksClamped flag', () => {
+    it('returns ticksClamped false for normal configs', () => {
+      const { result } = renderHook(() => useTickComputations(defaultOpts));
+      expect(result.current.ticksClamped).toBe(false);
+    });
+
+    it('returns ticksClamped true when major ticks exceed limit', () => {
+      const { result } = renderHook(() =>
+        useTickComputations({
+          ...defaultOpts,
+          tickSpacingMajor: 0.001,
+          valueScale: makeScale(0, 100, 60, 300),
+        })
+      );
+      expect(result.current.ticksClamped).toBe(true);
+    });
+
+    it('returns ticksClamped true when minor ticks exceed limit', () => {
+      const { result } = renderHook(() =>
+        useTickComputations({
+          ...defaultOpts,
+          tickSpacingMinor: 0.001,
+          valueScale: makeScale(0, 100, 60, 300),
+        })
+      );
+      expect(result.current.ticksClamped).toBe(true);
+    });
+
+    it('iteration guard prevents runaway loops with extreme range', () => {
+      const { result } = renderHook(() =>
+        useTickComputations({
+          ...defaultOpts,
+          minValue: 0,
+          maxValue: 6_000_000_000,
+          tickSpacingMajor: 10,
+          tickSpacingMinor: 1,
+          valueScale: makeScale(0, 6_000_000_000, 60, 300),
+        })
+      );
+      expect(result.current.tickAnglesMaj.length).toBeLessThanOrEqual(100);
+      expect(result.current.ticksClamped).toBe(true);
     });
   });
 

--- a/src/components/Gauge/useTickComputations.ts
+++ b/src/components/Gauge/useTickComputations.ts
@@ -5,17 +5,20 @@ import { line, type ScaleLinear } from 'd3';
 import { TickMapItemType } from '../TickMaps/types';
 import { dToR } from './utils';
 
-const MAX_TICKS = 500;
+const MAX_TICKS = 100;
 
 const generateTickAngles = (zeroTickAngle: number, maxTickAngle: number, majorDegree: number, minorDegree: number) => {
   if (majorDegree <= 0 || !isFinite(majorDegree)) {
-    return { tickMaj: [], tickMin: [] };
+    return { tickMaj: [], tickMin: [], clamped: false };
   }
 
+  let clamped = false;
   const majorAngles: number[] = [];
   let counter = 0;
+  let iterations = 0;
   for (let i = zeroTickAngle; i <= maxTickAngle; i = i + majorDegree) {
-    if (majorAngles.length >= MAX_TICKS) {
+    if (majorAngles.length >= MAX_TICKS || iterations++ > MAX_TICKS) {
+      clamped = true;
       break;
     }
     const tickAngle = zeroTickAngle + majorDegree * counter;
@@ -26,13 +29,15 @@ const generateTickAngles = (zeroTickAngle: number, maxTickAngle: number, majorDe
   }
 
   if (minorDegree <= 0 || !isFinite(minorDegree)) {
-    return { tickMaj: majorAngles, tickMin: [] };
+    return { tickMaj: majorAngles, tickMin: [], clamped };
   }
 
   const minorAngles: number[] = [];
   counter = 0;
+  iterations = 0;
   for (let j = zeroTickAngle; j <= maxTickAngle; j = j + minorDegree) {
-    if (minorAngles.length >= MAX_TICKS) {
+    if (minorAngles.length >= MAX_TICKS || iterations++ > MAX_TICKS) {
+      clamped = true;
       break;
     }
     let exists = 0;
@@ -46,7 +51,7 @@ const generateTickAngles = (zeroTickAngle: number, maxTickAngle: number, majorDe
     }
     counter++;
   }
-  return { tickMaj: majorAngles, tickMin: minorAngles };
+  return { tickMaj: majorAngles, tickMin: minorAngles, clamped };
 };
 
 const generateTickMajorLabels = (
@@ -59,13 +64,16 @@ const generateTickMajorLabels = (
   tickMaps: TickMapItemType[]
 ) => {
   if (majorDegree <= 0 || !isFinite(majorDegree)) {
-    return [];
+    return { labels: [], clamped: false };
   }
 
+  let clamped = false;
   let counter = 0;
+  let iterations = 0;
   const tickLabelText: string[] = [];
   for (let k = zeroTickAngle; k <= maxTickAngle; k = k + majorDegree) {
-    if (tickLabelText.length >= MAX_TICKS) {
+    if (tickLabelText.length >= MAX_TICKS || iterations++ > MAX_TICKS) {
+      clamped = true;
       break;
     }
     const step = minValue <= maxValue ? tickSpacingMajor : -tickSpacingMajor;
@@ -85,7 +93,7 @@ const generateTickMajorLabels = (
     tickLabelText.push(tickText);
     counter++;
   }
-  return tickLabelText;
+  return { labels: tickLabelText, clamped };
 };
 
 interface TickComputationOptions {
@@ -122,12 +130,12 @@ export const useTickComputations = (opts: TickComputationOptions) => {
     return Math.abs(minorA - scaleZero);
   }, [valueScale, opts.tickSpacingMinor]);
 
-  const { tickMaj: tickAnglesMaj, tickMin: tickAnglesMin } = useMemo(
+  const { tickMaj: tickAnglesMaj, tickMin: tickAnglesMin, clamped: anglesClamped } = useMemo(
     () => generateTickAngles(opts.zeroTickAngle, opts.maxTickAngle, tickSpacingMajDeg, tickSpacingMinDeg),
     [opts.zeroTickAngle, opts.maxTickAngle, tickSpacingMajDeg, tickSpacingMinDeg]
   );
 
-  const tickMajorLabels = useMemo(
+  const { labels: tickMajorLabels, clamped: labelsClamped } = useMemo(
     () =>
       generateTickMajorLabels(
         opts.zeroTickAngle,
@@ -185,5 +193,6 @@ export const useTickComputations = (opts: TickComputationOptions) => {
     opts.tickLengthMin,
   ]);
 
-  return { tickAnglesMaj, tickAnglesMin, tickMajorLabels, tickPathsMaj, tickPathsMin };
+  const ticksClamped = anglesClamped || labelsClamped;
+  return { tickAnglesMaj, tickAnglesMin, tickMajorLabels, tickPathsMaj, tickPathsMin, ticksClamped };
 };

--- a/src/components/Gauge/utils.test.tsx
+++ b/src/components/Gauge/utils.test.tsx
@@ -236,6 +236,27 @@ describe('Utils', () => {
       expect(path?.getAttribute('fill')).toBe('green');
     });
 
+    it('uses correct rotation for default angles (60/300)', () => {
+      const result = drawBand(0, 100, 'green', 200, 200, mockGaugeOptions, mockTheme);
+      const { container } = render(result as React.ReactElement);
+      const path = container.querySelector('path');
+      // 2 * zeroTickAngle + 180 = 2 * 60 + 180 = 300
+      expect(path?.getAttribute('transform')).toContain('rotate(300)');
+    });
+
+    it('uses correct rotation for non-default angles', () => {
+      const customAngles = {
+        ...mockGaugeOptions,
+        zeroTickAngle: 45,
+        maxTickAngle: 315,
+      } as GaugeOptions;
+      const result = drawBand(0, 100, 'green', 200, 200, customAngles, mockTheme);
+      const { container } = render(result as React.ReactElement);
+      const path = container.querySelector('path');
+      // 2 * 45 + 180 = 270, NOT 315 (maxTickAngle)
+      expect(path?.getAttribute('transform')).toContain('rotate(270)');
+    });
+
     it('works with inverted range options', () => {
       const invertedOptions = {
         ...mockGaugeOptions,

--- a/src/components/Gauge/utils.tsx
+++ b/src/components/Gauge/utils.tsx
@@ -102,7 +102,7 @@ export const drawBand = (
       key={bandKey}
       fill={theme2.visualization.getColorByName(color)}
       d={xc}
-      transform={`translate(${originX},${originY}) rotate(${options.maxTickAngle})`}
+      transform={`translate(${originX},${originY}) rotate(${2 * options.zeroTickAngle + 180})`}
     />
   );
 };

--- a/src/components/GaugePanel.tsx
+++ b/src/components/GaugePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   PanelProps,
   FieldDisplay,
@@ -9,8 +9,9 @@ import {
 import { GaugeOptions } from './types';
 import { Gauge } from './Gauge';
 import { css, cx } from '@emotion/css';
-import { useStyles2, useTheme2 } from '@grafana/ui';
+import { Icon, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { getComponentStyles } from './gauge_panel_styles';
+import { computeTickSpacing } from './Gauge/tick_spacing';
 
 interface Props extends PanelProps<GaugeOptions> {}
 
@@ -76,8 +77,30 @@ export const GaugePanel: React.FC<Props> = ({
 
   const metric = metrics[0];
 
+  const [ticksClamped, setTicksClamped] = useState(false);
+
+  const onTicksClamped = useCallback((clamped: boolean) => {
+    setTicksClamped(clamped);
+  }, []);
+
+  const suggestedSpacing = useMemo(() => {
+    if (!ticksClamped) {
+      return null;
+    }
+    return computeTickSpacing(options.minValue, options.maxValue);
+  }, [ticksClamped, options.minValue, options.maxValue]);
+
   return (
     <div className={cx(styles.wrapper, dimensionStyle)}>
+      {ticksClamped && suggestedSpacing && (
+        <div className={styles.warningIcon}>
+          <Tooltip
+            content={`Tick count exceeds maximum (100). Adjust tick spacing for your value range. Suggested major spacing: ${suggestedSpacing.majorSpacing}`}
+          >
+            <Icon name="exclamation-triangle" size="sm" />
+          </Tooltip>
+        </div>
+      )}
       <div className={cx(styles.container)}>
         <Gauge
           {...options}
@@ -95,6 +118,7 @@ export const GaugePanel: React.FC<Props> = ({
           tickLengthMaj={options.tickLengthMaj * gaugeRadiusCalc}
           tickLengthMin={options.tickLengthMin * gaugeRadiusCalc}
           thresholds={metric.field.thresholds ?? fieldConfig.defaults.thresholds}
+          onTicksClamped={onTicksClamped}
         />
       </div>
     </div>

--- a/src/components/GaugePanel.tsx
+++ b/src/components/GaugePanel.tsx
@@ -93,7 +93,7 @@ export const GaugePanel: React.FC<Props> = ({
   return (
     <div className={cx(styles.wrapper, dimensionStyle)}>
       {ticksClamped && suggestedSpacing && (
-        <div className={styles.warningIcon}>
+        <div className={styles.warningIcon} data-testid="tick-clamp-warning">
           <Tooltip
             content={`Tick count exceeds maximum (100). Adjust tick spacing for your value range. Suggested major spacing: ${suggestedSpacing.majorSpacing}`}
           >

--- a/src/components/TickMaps/TickMapEditor.tsx
+++ b/src/components/TickMaps/TickMapEditor.tsx
@@ -135,6 +135,9 @@ export const TickMapEditor: React.FC<Props> = ({ context, onChange }) => {
 
   return (
     <>
+      <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--text-secondary)' }}>
+        Replaces value at tick with specified text. The value setting must match one of the displayed values.
+      </div>
       <Button fill="solid" variant="primary" icon="plus" onClick={addItem}>
         Add Tick Map
       </Button>

--- a/src/components/editors/RangeEditor.test.tsx
+++ b/src/components/editors/RangeEditor.test.tsx
@@ -30,19 +30,22 @@ describe('RangeEditor', () => {
     expect(input?.value).toBe('100');
   });
 
-  it('calls onChange with the new value', () => {
+  it('updates option via onOptionsChange on blur', () => {
     const { container } = render(<RangeEditor {...defaultProps} />);
     const input = container.querySelector('input')!;
-    fireEvent.change(input, { target: { value: '500' } });
+    fireEvent.change(input, { target: { value: '200' } });
     fireEvent.blur(input);
-    expect(defaultProps.onChange).toHaveBeenCalledWith(500);
+    expect(defaultProps.context.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ maxValue: 200 })
+    );
   });
 
-  it('updates tick spacing when maxValue changes', () => {
+  it('auto-fills tick spacing when ticks would exceed limit', () => {
     const { container } = render(<RangeEditor {...defaultProps} />);
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '1000' } });
     fireEvent.blur(input);
+    // range=1000, current minor=1, 1000/1=1000 > 100 -> auto-fill
     // computeTickSpacing(0, 1000) -> major=100, minor=20
     expect(defaultProps.context.onOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -52,7 +55,36 @@ describe('RangeEditor', () => {
     );
   });
 
-  it('updates tick spacing when minValue changes', () => {
+  it('preserves tick spacing when ticks stay within limit', () => {
+    const props = {
+      ...defaultProps,
+      value: 100,
+      context: {
+        options: {
+          minValue: 0,
+          maxValue: 100,
+          tickSpacingMajor: 10,
+          tickSpacingMinor: 5,
+        },
+        onOptionsChange: jest.fn(),
+      } as any,
+    };
+    const { container } = render(<RangeEditor {...props} />);
+    const input = container.querySelector('input')!;
+    // Change max from 100 to 200. major=10 -> 200/10=20, minor=5 -> 200/5=40
+    // Both within 100, so spacing preserved
+    fireEvent.change(input, { target: { value: '200' } });
+    fireEvent.blur(input);
+    expect(props.context.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxValue: 200,
+        tickSpacingMajor: 10,
+        tickSpacingMinor: 5,
+      })
+    );
+  });
+
+  it('auto-fills tick spacing when minValue changes and ticks exceed limit', () => {
     const props = {
       ...defaultProps,
       value: 0,
@@ -62,6 +94,7 @@ describe('RangeEditor', () => {
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '-100' } });
     fireEvent.blur(input);
+    // range=200, current minor=1, 200/1=200 > 100 -> auto-fill
     // computeTickSpacing(-100, 100) -> range=200, major=20, minor=4
     expect(props.context.onOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -69,5 +102,14 @@ describe('RangeEditor', () => {
         tickSpacingMinor: 4,
       })
     );
+  });
+
+  it('syncs local value when external value prop changes', () => {
+    const { container, rerender } = render(<RangeEditor {...defaultProps} />);
+    const input = container.querySelector('input')!;
+    expect(input.value).toBe('100');
+
+    rerender(<RangeEditor {...defaultProps} value={500} />);
+    expect(input.value).toBe('500');
   });
 });

--- a/src/components/editors/RangeEditor.test.tsx
+++ b/src/components/editors/RangeEditor.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { RangeEditor } from './RangeEditor';
+
+describe('RangeEditor', () => {
+  const defaultProps = {
+    value: 100,
+    onChange: jest.fn(),
+    item: { path: 'maxValue' } as any,
+    context: {
+      options: {
+        minValue: 0,
+        maxValue: 100,
+        tickSpacingMajor: 10,
+        tickSpacingMinor: 1,
+      },
+      onOptionsChange: jest.fn(),
+    } as any,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a number input with the current value', () => {
+    const { container } = render(<RangeEditor {...defaultProps} />);
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe('100');
+  });
+
+  it('calls onChange with the new value', () => {
+    const { container } = render(<RangeEditor {...defaultProps} />);
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '500' } });
+    fireEvent.blur(input);
+    expect(defaultProps.onChange).toHaveBeenCalledWith(500);
+  });
+
+  it('updates tick spacing when maxValue changes', () => {
+    const { container } = render(<RangeEditor {...defaultProps} />);
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '1000' } });
+    fireEvent.blur(input);
+    // computeTickSpacing(0, 1000) -> major=100, minor=20
+    expect(defaultProps.context.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickSpacingMajor: 100,
+        tickSpacingMinor: 20,
+      })
+    );
+  });
+
+  it('updates tick spacing when minValue changes', () => {
+    const props = {
+      ...defaultProps,
+      value: 0,
+      item: { path: 'minValue' } as any,
+    };
+    const { container } = render(<RangeEditor {...props} />);
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '-100' } });
+    fireEvent.blur(input);
+    // computeTickSpacing(-100, 100) -> range=200, major=20, minor=4
+    expect(props.context.onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickSpacingMajor: 20,
+        tickSpacingMinor: 4,
+      })
+    );
+  });
+});

--- a/src/components/editors/RangeEditor.tsx
+++ b/src/components/editors/RangeEditor.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { StandardEditorProps } from '@grafana/data';
+import { Input } from '@grafana/ui';
 import { computeTickSpacing } from '../Gauge/tick_spacing';
 
 /**
@@ -20,13 +21,19 @@ interface EditorContext {
   onOptionsChange: (options: Record<string, unknown>) => void;
 }
 
+const MAX_TICKS = 100;
+
 interface Props extends StandardEditorProps<number> {}
 
-export const RangeEditor: React.FC<Props> = ({ value, onChange, item, context }) => {
+export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
   const [localValue, setLocalValue] = useState<string>(String(value ?? ''));
 
   const editorItem = item as unknown as EditorItem;
   const editorContext = context as unknown as EditorContext;
+
+  useEffect(() => {
+    setLocalValue(String(value ?? ''));
+  }, [value]);
 
   const handleBlur = useCallback(() => {
     const numericValue = parseFloat(localValue);
@@ -34,28 +41,39 @@ export const RangeEditor: React.FC<Props> = ({ value, onChange, item, context })
       return;
     }
 
-    onChange(numericValue);
-
     const options = editorContext.options;
     const min = editorItem.path === 'minValue' ? numericValue : (options.minValue as number);
     const max = editorItem.path === 'maxValue' ? numericValue : (options.maxValue as number);
+    const range = Math.abs(max - min);
+    const currentMajor = options.tickSpacingMajor as number;
+    const currentMinor = options.tickSpacingMinor as number;
 
-    const { majorSpacing, minorSpacing } = computeTickSpacing(min, max);
-    editorContext.onOptionsChange({
-      ...options,
-      [editorItem.path]: numericValue,
-      tickSpacingMajor: majorSpacing,
-      tickSpacingMinor: minorSpacing,
-    });
-  }, [localValue, onChange, editorItem, editorContext]);
+    const wouldExceedLimit =
+      (currentMajor > 0 && range / currentMajor > MAX_TICKS) ||
+      (currentMinor > 0 && range / currentMinor > MAX_TICKS);
+
+    if (wouldExceedLimit) {
+      const { majorSpacing, minorSpacing } = computeTickSpacing(min, max);
+      editorContext.onOptionsChange({
+        ...options,
+        [editorItem.path]: numericValue,
+        tickSpacingMajor: majorSpacing,
+        tickSpacingMinor: minorSpacing,
+      });
+    } else {
+      editorContext.onOptionsChange({
+        ...options,
+        [editorItem.path]: numericValue,
+      });
+    }
+  }, [localValue, editorItem, editorContext]);
 
   return (
-    <input
+    <Input
       type="number"
       value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
+      onChange={(e) => setLocalValue(e.currentTarget.value)}
       onBlur={handleBlur}
-      style={{ width: '100%' }}
     />
   );
 };

--- a/src/components/editors/RangeEditor.tsx
+++ b/src/components/editors/RangeEditor.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useState } from 'react';
+import { StandardEditorProps } from '@grafana/data';
+import { computeTickSpacing } from '../Gauge/tick_spacing';
+
+/**
+ * Extended item type that includes `path`, which Grafana provides at runtime
+ * via OptionsEditorItem but is not surfaced through StandardEditorProps.
+ */
+interface EditorItem {
+  path: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Extended context type that includes `onOptionsChange`, which Grafana provides
+ * at runtime but is not declared on StandardEditorContext.
+ */
+interface EditorContext {
+  options: Record<string, unknown>;
+  onOptionsChange: (options: Record<string, unknown>) => void;
+}
+
+interface Props extends StandardEditorProps<number> {}
+
+export const RangeEditor: React.FC<Props> = ({ value, onChange, item, context }) => {
+  const [localValue, setLocalValue] = useState<string>(String(value ?? ''));
+
+  const editorItem = item as unknown as EditorItem;
+  const editorContext = context as unknown as EditorContext;
+
+  const handleBlur = useCallback(() => {
+    const numericValue = parseFloat(localValue);
+    if (isNaN(numericValue)) {
+      return;
+    }
+
+    onChange(numericValue);
+
+    const options = editorContext.options;
+    const min = editorItem.path === 'minValue' ? numericValue : (options.minValue as number);
+    const max = editorItem.path === 'maxValue' ? numericValue : (options.maxValue as number);
+
+    const { majorSpacing, minorSpacing } = computeTickSpacing(min, max);
+    editorContext.onOptionsChange({
+      ...options,
+      [editorItem.path]: numericValue,
+      tickSpacingMajor: majorSpacing,
+      tickSpacingMinor: minorSpacing,
+    });
+  }, [localValue, onChange, editorItem, editorContext]);
+
+  return (
+    <input
+      type="number"
+      value={localValue}
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={handleBlur}
+      style={{ width: '100%' }}
+    />
+  );
+};

--- a/src/components/editors/RangeEditor.tsx
+++ b/src/components/editors/RangeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { StandardEditorProps } from '@grafana/data';
 import { Input } from '@grafana/ui';
 import { computeTickSpacing } from '../Gauge/tick_spacing';
@@ -26,17 +26,23 @@ const MAX_TICKS = 100;
 interface Props extends StandardEditorProps<number> {}
 
 export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
-  const [localValue, setLocalValue] = useState<string>(String(value ?? ''));
+  const [editValue, setEditValue] = useState<string | null>(null);
 
   const editorItem = item as unknown as EditorItem;
   const editorContext = context as unknown as EditorContext;
 
-  useEffect(() => {
-    setLocalValue(String(value ?? ''));
+  const handleFocus = useCallback(() => {
+    setEditValue(String(value ?? ''));
   }, [value]);
 
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditValue(e.currentTarget.value);
+  }, []);
+
   const handleBlur = useCallback(() => {
-    const numericValue = parseFloat(localValue);
+    const raw = editValue ?? '';
+    setEditValue(null);
+    const numericValue = parseFloat(raw);
     if (isNaN(numericValue)) {
       return;
     }
@@ -66,13 +72,14 @@ export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
         [editorItem.path]: numericValue,
       });
     }
-  }, [localValue, editorItem, editorContext]);
+  }, [editValue, editorItem, editorContext]);
 
   return (
     <Input
       type="number"
-      value={localValue}
-      onChange={(e) => setLocalValue(e.currentTarget.value)}
+      value={editValue ?? String(value ?? '')}
+      onFocus={handleFocus}
+      onChange={handleChange}
       onBlur={handleBlur}
     />
   );

--- a/src/components/gauge_panel_styles.ts
+++ b/src/components/gauge_panel_styles.ts
@@ -6,6 +6,14 @@ export const getComponentStyles = (theme: GrafanaTheme2) => {
     wrapper: css`
       position: relative;
     `,
+    warningIcon: css`
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      z-index: 1;
+      color: ${theme.colors.warning.text};
+      cursor: help;
+    `,
     container: css`
       align-items: center;
       justify-content: center;

--- a/src/components/gauge_panel_styles.ts
+++ b/src/components/gauge_panel_styles.ts
@@ -12,6 +12,7 @@ export const getComponentStyles = (theme: GrafanaTheme2) => {
       right: 4px;
       z-index: 1;
       color: ${theme.colors.warning.text};
+      opacity: 0.7;
       cursor: help;
     `,
     container: css`

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -87,6 +87,7 @@ export interface GaugeOptions {
   showThresholdStateOnBackground: boolean;
   //
   thresholds: ThresholdsConfig | undefined;
+  onTicksClamped?: (clamped: boolean) => void;
 }
 
 export enum FontFamilies {

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,7 @@ import {
 import { PanelMigrationHandler } from './migrations';
 import { TickMapEditor } from 'components/TickMaps/TickMapEditor';
 import { TickMapItemType } from 'components/TickMaps/types';
+import { RangeEditor } from 'components/editors/RangeEditor';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setMigrationHandler(PanelMigrationHandler)
@@ -219,26 +220,22 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         showIf: (c) => c.markerStartEnabled === true,
       })
       // Limits
-      .addNumberInput({
+      .addCustomEditor({
         name: 'Minimum Value',
+        id: 'minValue',
         path: 'minValue',
-        description: 'Minimum value displayed by the gauge (left side)',
+        description: 'Minimum value displayed by the gauge (left side). Changing this auto-adjusts tick spacing.',
         defaultValue: 0,
-        settings: {
-          placeHolder: '0',
-          integer: false,
-        },
+        editor: RangeEditor,
         category: ['Limits'],
       })
-      .addNumberInput({
+      .addCustomEditor({
         name: 'Maximum Value',
+        id: 'maxValue',
         path: 'maxValue',
-        description: 'Maximum value displayed by the gauge (right side)',
+        description: 'Maximum value displayed by the gauge (right side). Changing this auto-adjusts tick spacing.',
         defaultValue: 100,
-        settings: {
-          placeHolder: '100',
-          integer: false,
-        },
+        editor: RangeEditor,
         category: ['Limits'],
       })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -36,7 +36,7 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
     builder
       // General Settings
       .addBooleanSwitch({
-        name: 'Show Display Name',
+        name: 'Show Display Name on Gauge',
         path: 'showTitle',
         defaultValue: false,
         category: ['Standard options'],
@@ -55,7 +55,26 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
       })
 
       // Font Settings
-      // Value Font
+      .addSelect({
+        name: 'Display Name Font',
+        path: 'titleFont',
+        description: 'Font used for the display name shown above the value',
+        category: ['Font Settings'],
+        defaultValue: FontFamilyOptions[3].value,
+        settings: {
+          options: FontFamilyOptions,
+        },
+      })
+      .addSelect({
+        name: 'Display Name Font Size',
+        path: 'titleFontSize',
+        description: 'Font size of the display name',
+        category: ['Font Settings'],
+        defaultValue: FontSizes[17].value,
+        settings: {
+          options: FontSizes,
+        },
+      })
       .addSelect({
         name: 'Value Font',
         path: 'valueFont',
@@ -66,34 +85,10 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
           options: FontFamilyOptions,
         },
       })
-      // unitsLabelFontSize
       .addSelect({
         name: 'Value Font Size',
         path: 'valueFontSize',
         description: 'Font Size of Value',
-        category: ['Font Settings'],
-        defaultValue: FontSizes[17].value,
-        settings: {
-          options: FontSizes,
-        },
-      })
-      // Font Settings
-      // Title Font
-      .addSelect({
-        name: 'Title Font',
-        path: 'titleFont',
-        description: 'The font of the value text, at the bottom of the gauge',
-        category: ['Font Settings'],
-        defaultValue: FontFamilyOptions[3].value,
-        settings: {
-          options: FontFamilyOptions,
-        },
-      })
-      // unitsLabelFontSize
-      .addSelect({
-        name: 'Title Font Size',
-        path: 'titleFontSize',
-        description: 'Font Size of Title',
         category: ['Font Settings'],
         defaultValue: FontSizes[17].value,
         settings: {
@@ -337,7 +332,7 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
       })
       // valueYOffset
       .addNumberInput({
-        name: 'Value Y-Offset',
+        name: 'Value Y-Offset (Vertical)',
         path: 'valueYOffset',
         description:
           'Adjust the displayed value up or down the Y-Axis, use negative value to move up, positive for down',
@@ -349,10 +344,10 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
       })
       // titleYOffset
       .addNumberInput({
-        name: 'Title Y-Offset',
+        name: 'Display Name Y-Offset (Vertical)',
         path: 'titleYOffset',
         description:
-          'Adjust the displayed title up or down the Y-Axis, use negative title to move up, positive for down',
+          'Adjust the display name up or down the Y-Axis, use negative value to move up, positive for down',
         defaultValue: 0,
         settings: {
           integer: true,
@@ -549,7 +544,6 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         name: 'Tick Maps',
         id: 'tickMapConfig',
         path: 'tickMapConfig',
-        description: 'Tick Maps',
         editor: TickMapEditor,
         defaultValue: {
           tickMaps: [] as TickMapItemType[],

--- a/src/module.ts
+++ b/src/module.ts
@@ -157,9 +157,9 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         name: 'Needle Cross Limit Degrees',
         path: 'needleCrossLimitDegrees',
         description: 'How many degrees to cross below and above minimum and maximum limit, default is 5 degrees',
-        defaultValue: 10,
+        defaultValue: 5,
         settings: {
-          placeHolder: '10',
+          placeHolder: '5',
           min: 0,
           integer: true,
         },

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,6 +35,13 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setPanelOptions((builder) => {
     builder
       // General Settings
+      .addBooleanSwitch({
+        name: 'Show Display Name',
+        path: 'showTitle',
+        defaultValue: false,
+        category: ['Standard options'],
+        description: 'Show the field or series name above the value on the gauge',
+      })
       // stat (operator)
       .addSelect({
         name: 'Stat',
@@ -45,13 +52,6 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         settings: {
           options: OperatorOptions,
         },
-      })
-      .addBooleanSwitch({
-        name: 'Show title',
-        path: 'showTitle',
-        defaultValue: false,
-        category: ['Standard options'],
-        description: 'Show the series title/name in the gauge',
       })
 
       // Font Settings


### PR DESCRIPTION
## Summary

Fixes #63 — the browser would hang when gauge max value was very large (e.g. 6 billion) because tick generation loops ran unchecked.

## Changes

### Bug Fixes

- Lower `MAX_TICKS` from 500 to 100 to prevent excessive SVG rendering
- Add iteration guard to all tick generation loops to prevent runaway execution
- Track `ticksClamped` flag through `useTickComputations` → `Gauge` → `GaugePanel`
- Fix threshold band angular misalignment with gauge ticks for non-default angle configs
- Fix `needleCrossLimitDegrees` default (10 → 5) to match description

### New Features

- **`computeTickSpacing` utility** — calculates human-friendly ("nice number") tick intervals using the 1-2-5 series
- **`RangeEditor` custom editor** — auto-fills tick spacing only when the new range would exceed the 100-tick limit
- **Warning icon** — renders a subtle tooltip warning when tick count is clamped

### Panel Editor UX

- Rename "Show title" → "Show Display Name on Gauge"
- Rename "Title Font/Size" → "Display Name Font/Size"
- Rename Y-Offset options to include "(Vertical)" suffix
- Reorder font settings: Display Name, Value, Tick Label
- Add inline description to Tick Maps editor section
- Increase vertical spacing between display name and value labels

### Code Quality

- Use `@grafana/ui` `Input` component in `RangeEditor` for theme consistency
- Focus/blur state toggle for edit value (no `useEffect`+`setState` or ref reads during render)
- Single `onOptionsChange` call instead of redundant `onChange` + `onOptionsChange`

### Testing Infrastructure

- Suppress jsdom SVG tag warnings and i18next banner in test output

## Test Plan

- [x] `tick_spacing.test.ts` — nice number rounding, custom targets, edge cases
- [x] `useTickComputations.test.ts` — clamped flag, iteration guard with extreme ranges
- [x] `Gauge.test.tsx` — `onTicksClamped` callback for normal and excessive configs
- [x] `RangeEditor.test.tsx` — auto-fill, preserve spacing, external value sync
- [x] `utils.test.tsx` — band rotation for default and non-default angles
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm spellcheck` pass