### PR TITLE
fix: allow decimal values for Needle Length Stem (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ All changes noted here.
 - Fix threshold band angular misalignment with gauge ticks when using
   non-default `zeroTickAngle`/`maxTickAngle` values; the `drawBand`
   rotation is now computed as `2 * zeroTickAngle + 180` instead of
-  being hardcoded to `maxTickAngle`
+  being hardcoded to `maxTickAngle` (fixes #109)
+- Fix Needle Length Stem ignoring decimal values by changing
+  `integer: true` to `integer: false` (fixes #110)
 
 ### Type Safety
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -461,7 +461,7 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         settings: {
           placeHolder: '0',
           min: 0,
-          integer: true,
+          integer: false,
         },
         category: ['Radial Customization'],
       })


### PR DESCRIPTION
## Summary

Fixes #110 — the Needle Length Stem option had `integer: true` in the editor config, silently discarding decimal values.

## Changes

- Change `integer: true` to `integer: false` for the `needleLengthNeg` option in `module.ts`
- Consistent with all other radial customization options (padding, edge width, tick lengths) which are percentages of gauge radius
- Add changelog entries for #109 and #110 fixes

## Test Plan

- [x] Verify decimal values can be entered in the Needle Length Stem field
- [x] `pnpm typecheck` passes