### PR TITLE
feat: add toggles to hide value and tick labels (#101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,9 @@ pnpm exec playwright test --ui    # Interactive UI mode
   to `cspell.config.json` if they are legitimate.
 - **Always run `pnpm typecheck`** when `src/` files
   are changed and fix any type errors before committing.
+- **NEVER comment on GitHub issues or PRs** unless the
+  user explicitly asks. Draft the response and show it
+  to the user first. Only post when told to do so.
 - **NEVER commit unless the user explicitly asks.**
   Do not commit as part of completing a task.
 - **NEVER push unless the user explicitly asks.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ All changes noted here.
   consistency
 - Sync `RangeEditor` local state when external value prop changes
   (undo/reset)
+- Add "Show Value on Gauge" toggle to hide/show the numeric value
+  display (fixes #101)
+- Add "Show Tick Labels" toggle to hide/show the tick mark labels
+  (fixes #101)
 
 ### Panel Editor UX
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The React port has separated the configuration options into multiple searchable 
 | Option                       | Description                                                               |
 | ---------------------------- | ------------------------------------------------------------------------- |
 | Show Display Name on Gauge   | Show the field or series name above the value on the gauge                |
+| Show Value on Gauge          | Show the numeric value on the gauge                                       |
+| Show Tick Labels             | Show numeric labels next to the major ticks                               |
 | Stat                         | The statistic to be displayed on the gauge                                |
 | Unit                         | A unit for the value displayed. This will be used to abbreviate as needed |
 | Decimals                     | Maximum number of decimals to display if any are required                 |

--- a/src/components/Gauge/Gauge.test.tsx
+++ b/src/components/Gauge/Gauge.test.tsx
@@ -52,6 +52,8 @@ const defaultOptions: GaugeOptions = {
   displayFormatted: '50.0',
   displayValue: 50,
   showTitle: true,
+  showValue: true,
+  showTickLabels: true,
   displayTitle: 'Test Gauge',
   operatorName: 'lastNotNull',
   valueYOffset: 0,

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -353,11 +353,11 @@ export const Gauge: React.FC<GaugeOptions> = (options) => {
           {circleGroup}
           {thresholdBands}
           {ticks}
-          {majorTickLabelElements}
+          {options.showTickLabels !== false && majorTickLabelElements}
           {needleMarkers}
           {needleElement}
           {titleLabel}
-          {valueLabel}
+          {options.showValue !== false && valueLabel}
         </g>
       </svg>
     </div>

--- a/src/components/GaugePanel.test.tsx
+++ b/src/components/GaugePanel.test.tsx
@@ -29,6 +29,8 @@ const defaultOptions: GaugeOptions = {
   displayFormatted: '',
   displayValue: null,
   showTitle: false,
+  showValue: true,
+  showTickLabels: true,
   displayTitle: '',
   operatorName: 'lastNotNull',
   valueYOffset: 0,

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -6,6 +6,8 @@ export interface GaugeOptions {
   displayFormatted: string;
   displayValue: number | null;
   showTitle: boolean;
+  showValue: boolean;
+  showTickLabels: boolean;
   displayTitle: string;
   // General
   operatorName: string;

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -326,6 +326,8 @@ export const migrateDefaults = (angular: AngularOptions) => {
     displayValue: null,
     displayTitle: '',
     showTitle: false,
+    showValue: true,
+    showTickLabels: true,
     thresholds: undefined,
     showThresholdStateOnValue: false,
     showThresholdStateOnTitle: false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,20 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
         category: ['Standard options'],
         description: 'Show the field or series name above the value on the gauge',
       })
+      .addBooleanSwitch({
+        name: 'Show Value on Gauge',
+        path: 'showValue',
+        defaultValue: true,
+        category: ['Standard options'],
+        description: 'Show the numeric value on the gauge',
+      })
+      .addBooleanSwitch({
+        name: 'Show Tick Labels',
+        path: 'showTickLabels',
+        defaultValue: true,
+        category: ['Standard options'],
+        description: 'Show numeric labels next to the major ticks',
+      })
       // stat (operator)
       .addSelect({
         name: 'Stat',


### PR DESCRIPTION
## Summary

Fixes #101 — adds options to independently show/hide the value display and tick labels on the gauge.

## Changes

- Add `showValue` and `showTickLabels` boolean fields to `GaugeOptions`
- Add "Show Value on Gauge" and "Show Tick Labels" switches in Standard options
- Conditionally render value label and tick label elements in `Gauge.tsx`
- Uses `!== false` check for backward compatibility with existing dashboards
- Set defaults to `true` in migration handler for Angular panel upgrades
- Add critical rule to AGENTS.md: never comment on issues/PRs without explicit instruction
- Update README and CHANGELOG

## Test Plan

- [x] All 262 tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm spellcheck` passes
- [x] Verify toggling "Show Value on Gauge" hides/shows the numeric value
- [x] Verify toggling "Show Tick Labels" hides/shows the tick mark labels
- [ ] Verify existing dashboards without these fields still render labels