### PR TITLE
fix: restore onChange call so min/max values actually save

### DIFF
--- a/src/components/editors/RangeEditor.test.tsx
+++ b/src/components/editors/RangeEditor.test.tsx
@@ -30,14 +30,12 @@ describe('RangeEditor', () => {
     expect(input?.value).toBe('100');
   });
 
-  it('updates option via onOptionsChange on blur', () => {
+  it('calls onChange with the new value on blur', () => {
     const { container } = render(<RangeEditor {...defaultProps} />);
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '200' } });
     fireEvent.blur(input);
-    expect(defaultProps.context.onOptionsChange).toHaveBeenCalledWith(
-      expect.objectContaining({ maxValue: 200 })
-    );
+    expect(defaultProps.onChange).toHaveBeenCalledWith(200);
   });
 
   it('auto-fills tick spacing when ticks would exceed limit', () => {
@@ -72,16 +70,11 @@ describe('RangeEditor', () => {
     const { container } = render(<RangeEditor {...props} />);
     const input = container.querySelector('input')!;
     // Change max from 100 to 200. major=10 -> 200/10=20, minor=5 -> 200/5=40
-    // Both within 100, so spacing preserved
+    // Both within 100, so spacing preserved — only onChange called
     fireEvent.change(input, { target: { value: '200' } });
     fireEvent.blur(input);
-    expect(props.context.onOptionsChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        maxValue: 200,
-        tickSpacingMajor: 10,
-        tickSpacingMinor: 5,
-      })
-    );
+    expect(props.onChange).toHaveBeenCalledWith(200);
+    expect(props.context.onOptionsChange).not.toHaveBeenCalled();
   });
 
   it('auto-fills tick spacing when minValue changes and ticks exceed limit', () => {

--- a/src/components/editors/RangeEditor.tsx
+++ b/src/components/editors/RangeEditor.tsx
@@ -18,14 +18,14 @@ interface EditorItem {
  */
 interface EditorContext {
   options: Record<string, unknown>;
-  onOptionsChange: (options: Record<string, unknown>) => void;
+  onOptionsChange?: (options: Record<string, unknown>) => void;
 }
 
 const MAX_TICKS = 100;
 
 interface Props extends StandardEditorProps<number> {}
 
-export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
+export const RangeEditor: React.FC<Props> = ({ value, onChange, item, context }) => {
   const [editValue, setEditValue] = useState<string | null>(null);
 
   const editorItem = item as unknown as EditorItem;
@@ -47,6 +47,8 @@ export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
       return;
     }
 
+    onChange(numericValue);
+
     const options = editorContext.options;
     const min = editorItem.path === 'minValue' ? numericValue : (options.minValue as number);
     const max = editorItem.path === 'maxValue' ? numericValue : (options.maxValue as number);
@@ -58,7 +60,7 @@ export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
       (currentMajor > 0 && range / currentMajor > MAX_TICKS) ||
       (currentMinor > 0 && range / currentMinor > MAX_TICKS);
 
-    if (wouldExceedLimit) {
+    if (wouldExceedLimit && editorContext.onOptionsChange) {
       const { majorSpacing, minorSpacing } = computeTickSpacing(min, max);
       editorContext.onOptionsChange({
         ...options,
@@ -66,13 +68,8 @@ export const RangeEditor: React.FC<Props> = ({ value, item, context }) => {
         tickSpacingMajor: majorSpacing,
         tickSpacingMinor: minorSpacing,
       });
-    } else {
-      editorContext.onOptionsChange({
-        ...options,
-        [editorItem.path]: numericValue,
-      });
     }
-  }, [editValue, editorItem, editorContext]);
+  }, [editValue, onChange, editorItem, editorContext]);
 
   return (
     <Input


### PR DESCRIPTION
## Summary

The RangeEditor custom editor for min/max values was not persisting changes. Values always reverted to 0 and 100.

## Root Cause

The editor was only calling `context.onOptionsChange` (which is not part of Grafana's public `StandardEditorContext` API and may not exist at runtime) and never calling the standard `onChange` callback. This meant the field value was never saved.

## Changes

- Always call `onChange(numericValue)` to save the field value via Grafana's guaranteed API
- Only call `onOptionsChange` when tick spacing also needs updating (ticks would exceed 100 limit)
- Guard `onOptionsChange` with existence check (marked optional with `?`)
- Update tests to match new behavior

## Test Plan

- [x] All tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Verify min/max values persist after editing
- [x] Verify tick spacing auto-adjusts when new range exceeds 100-tick limit