### PR TITLE
chore(ci): add lint-actions workflow (actionlint + zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "has-backend=true" >> $GITHUB_OUTPUT
+            echo "has-backend=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go environment
@@ -85,7 +85,7 @@ jobs:
         run: |
           if [ -f "playwright.config.ts" ]
           then
-            echo "has-e2e=true" >> $GITHUB_OUTPUT
+            echo "has-e2e=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Sign plugin
@@ -97,19 +97,22 @@ jobs:
         run: |
           sudo apt-get install jq
 
-          export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
-          export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
-          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
+          GRAFANA_PLUGIN_ID=$(jq -r .id dist/plugin.json)
+          GRAFANA_PLUGIN_VERSION=$(jq -r .info.version dist/plugin.json)
+          GRAFANA_PLUGIN_ARTIFACT="${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip"
+          export GRAFANA_PLUGIN_ID GRAFANA_PLUGIN_VERSION GRAFANA_PLUGIN_ARTIFACT
 
-          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
-          echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
-          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+          {
+            echo "plugin-id=${GRAFANA_PLUGIN_ID}"
+            echo "plugin-version=${GRAFANA_PLUGIN_VERSION}"
+            echo "archive=${GRAFANA_PLUGIN_ARTIFACT}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Package plugin
         id: package-plugin
         run: |
-          mv dist ${PLUGIN_ID}
-          zip ${ARCHIVE} ${PLUGIN_ID} -r
+          mv dist "${PLUGIN_ID}"
+          zip "${ARCHIVE}" "${PLUGIN_ID}" -r
         env:
           ARCHIVE: ${{ steps.metadata.outputs.archive }}
           PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
@@ -117,7 +120,7 @@ jobs:
       - name: Check plugin.json
         run: |
           docker run --pull=always \
-            -v $PWD/${ARCHIVE}:/archive.zip \
+            -v "$PWD/${ARCHIVE}:/archive.zip" \
             grafana/plugin-validator-cli -analyzer=metadatavalid /archive.zip
         env:
           ARCHIVE: ${{ steps.metadata.outputs.archive }}

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -23,11 +23,9 @@ jobs:
         run: pnpm run build
       - name: Find module.ts or module.tsx
         id: find-module-ts
-        run: >-
-          MODULETS="$(find ./src -type f \( -name "module.ts" -o -name
-          "module.tsx" \))"
-
-          echo "modulets=${MODULETS}" >> $GITHUB_OUTPUT
+        run: |
+          MODULETS="$(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \))"
+          echo "modulets=${MODULETS}" >> "$GITHUB_OUTPUT"
 
       - name: Compatibility check
         uses: grafana/plugin-actions/is-compatible@is-compatible/v1.0.3

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,45 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+# Cancel superseded PR runs when new commits land; let push-to-main runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/version-bump-changelog.yml
+++ b/.github/workflows/version-bump-changelog.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-latest
 
     steps:
       - name: Version bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,15 @@ All changes noted here.
 - Remove `.github/dependabot.yml` (superseded by Renovate)
 - Add `.github/workflows/lint-actions.yml` — runs `actionlint` and
   `zizmor` on PRs and pushes to `main` that touch `.github/workflows/**`
+- Fix actionlint findings surfaced by the new workflow:
+  - Quote `$GITHUB_OUTPUT`, `$PWD`, and metadata vars in `ci.yml`
+    (SC2086); drop useless `cat` and consolidate `>>` redirects in
+    the `Get plugin metadata` step (SC2002, SC2129, SC2155)
+  - Quote `$GITHUB_OUTPUT` in `is-compatible.yml` and collapse the
+    folded-scalar `run:` into a plain block
+  - Replace `ubuntu-x64-small` runner label with `ubuntu-latest` in
+    `version-bump-changelog.yml` (scaffolding leftover; this repo is
+    not on Grafana Labs self-hosted runners)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ All changes noted here.
   (pending `grafanaDependency` upper-bound bump), and a rule pinning
   `@types/node` below v25 to match `engines.node >= 24`
 - Remove `.github/dependabot.yml` (superseded by Renovate)
+- Add `.github/workflows/lint-actions.yml` — runs `actionlint` and
+  `zizmor` on PRs and pushes to `main` that touch `.github/workflows/**`
 
 ### New Features
 


### PR DESCRIPTION
## Summary

Adds a new CI workflow that lints GitHub Actions on changes to `.github/workflows/**`.

## Changes

- `.github/workflows/lint-actions.yml` — runs:
  - `actionlint` (raven-actions/actionlint@v2.1.2) for syntax/shell checks
  - `zizmor` (zizmorcore/zizmor-action@v0.5.3) for security checks

Both third-party actions are pinned by full commit SHA with a trailing version comment.

## Follow-up

`zizmor` may flag existing workflows that pin actions by tag instead of SHA. Migration of other workflows and an `AGENTS.md` policy update will follow in a separate PR.