### PR TITLE
docs: update AGENTS.md Action Pinning rule to SHA pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,21 @@ The CI workflow (`ci.yml`) is an inline workflow (not a reusable workflow call) 
 
 ### Action Pinning
 
-Pin all GitHub Actions to **version tags** (e.g., `@v6`, `@v4.0.0`), not commit SHAs.
-This keeps workflows readable and consistent.
+Pin every third-party GitHub Action to a **full-length commit SHA**
+with a trailing version comment:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+Enforced by `zizmor` in `.github/workflows/lint-actions.yml`. Tags can
+be moved silently and are not safe as a pin.
+
+To resolve a tag to a SHA:
+
+```bash
+gh api repos/<owner>/<repo>/commits/<tag> -q .sha
+```
 
 ## Version Bumping & Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ All changes noted here.
   `release-please.yml`, `release.yml`, and
   `version-bump-changelog.yml`
 
+### Docs
+
+- Update `AGENTS.md` Action Pinning rule: require full-length commit
+  SHAs with a trailing version comment (was: version tags). Reflects
+  the `zizmor`-enforced policy.
+
 ### New Features
 
 - Add `computeTickSpacing` utility that calculates human-friendly


### PR DESCRIPTION
## Summary

Brings `AGENTS.md` in line with the policy now enforced in CI (#166 added zizmor; #167 migrated every workflow to SHA pins).

## Change

`AGENTS.md` > Action Pinning:

- **Before:** pin to version tags.
- **After:** pin to full-length commit SHAs with a trailing version comment. Includes an example line and the `gh api` command to resolve a tag to a SHA.

## Verification

- [x] `markdownlint-cli2 AGENTS.md CHANGELOG.md` — 0 errors