### PR TITLE
fix(e2e): read Grafana version from bootData, not the Help button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,15 @@ All changes noted here.
   test output via `jest-setup.js` console filter
 - Suppress i18next promotional banner in test output
 
+### E2E Fixes
+
+- Rewrite `tests/grafana-version.spec.ts` to read the Grafana version
+  from the `grafanaVersion` fixture in `@grafana/plugin-e2e` (which
+  reads `window.grafanaBootData.settings.buildInfo.version`) instead
+  of clicking the Help toolbar button. Avoids the Grafana 13.x /
+  React 19 preview portal overlay that intercepted the click and
+  timed out the test (fixes #164).
+
 ### E2E Testing
 
 - Add Playwright config with `@grafana/plugin-e2e` auth and Chromium project

--- a/tests/grafana-version.spec.ts
+++ b/tests/grafana-version.spec.ts
@@ -1,10 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@grafana/plugin-e2e';
 
-test('Check Grafana Version from Help Button', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
-  const locator = page.getByRole('button', { name: 'Help' });
-  await locator.waitFor();
-  await locator.click();
-  const versionPattern = RegExp('Grafana v\\d+');
-  await expect(page.getByText(versionPattern)).toContainText('Grafana v');
+test('Check Grafana Version from bootData', async ({ grafanaVersion }) => {
+  expect(grafanaVersion).toMatch(/^\d+\.\d+\.\d+/);
 });


### PR DESCRIPTION
Closes #164.

## Summary

`tests/grafana-version.spec.ts` now reads the Grafana version through the `grafanaVersion` fixture in `@grafana/plugin-e2e`, which pulls it from `window.grafanaBootData.settings.buildInfo.version`. The old test clicked the Help toolbar button and scraped the menu — that click started timing out against `grafana-enterprise@13.0.1` and `dev-preview-react19` because a portal overlay intercepts pointer events in the new Grafana chrome.

Bypassing the UI entirely keeps the test doing what it was meant to do (smoke-check Grafana came up and reported a version) without depending on Grafana's internal DOM.

## Why this over `@grafana/plugin-e2e` *selectors*

`@grafana/e2e-selectors` does not expose a selector for the Help menu or the version string. The `grafanaVersion` fixture is the officially supported path for this assertion.

## Diff

```ts
-import { test, expect } from '@playwright/test';
-
-test('Check Grafana Version from Help Button', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
-  const locator = page.getByRole('button', { name: 'Help' });
-  await locator.waitFor();
-  await locator.click();
-  const versionPattern = RegExp('Grafana v\\d+');
-  await expect(page.getByText(versionPattern)).toContainText('Grafana v');
-});
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Check Grafana Version from bootData', async ({ grafanaVersion }) => {
+  expect(grafanaVersion).toMatch(/^\d+\.\d+\.\d+/);
+});
```

## Verification

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm exec playwright test --list` — test discovered
- [x] `pnpm spellcheck` — 0 errors
- [x] `markdownlint-cli2 CHANGELOG.md` — 0 errors
- [ ] CI green across the e2e matrix, including `grafana-enterprise@13.0.1` and `dev-preview-react19`

## Not in this PR

- A plugin-level smoke test (render a gauge, assert SVG elements). Deferred — this PR's scope is fixing the regression from #164.