### PR TITLE
test(e2e): add plugin-level gauge smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,14 @@ All changes noted here.
   of clicking the Help toolbar button. Avoids the Grafana 13.x /
   React 19 preview portal overlay that intercepted the click and
   timed out the test (fixes #164).
+- Add plugin-level smoke test `tests/gauge-smoke.spec.ts` plus a
+  provisioned dashboard `provisioning/dashboards/dashboards/D3Gauge-Smoke.json`.
+  The test navigates to the provisioned `Smoke Gauge` panel (uid
+  `briangann-gauge-smoke`), waits for the gauge SVG to become visible,
+  and asserts the render output (multiple `<path>` elements and at least
+  one `<text>` label). The panel is located via `getPanelById(1)` and
+  the gauge SVG is disambiguated from the panel-header icon by its
+  `viewBox="0,0,…"` attribute.
 
 ### E2E Testing
 

--- a/provisioning/dashboards/dashboards/D3Gauge-Smoke.json
+++ b/provisioning/dashboards/dashboards/D3Gauge-Smoke.json
@@ -1,0 +1,129 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "testdata", "uid": "P53465F745837BCFD" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "red", "value": 90 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "allowNeedleCrossLimits": false,
+        "animateNeedleValueTransition": false,
+        "animateNeedleValueTransitionSpeed": 0,
+        "edgeWidth": 0.05,
+        "formatTickLabelsWithUnit": false,
+        "gaugeRadius": 0,
+        "innerColor": "#ffffff",
+        "markerEndEnabled": false,
+        "markerEndShape": "arrow",
+        "markerStartEnabled": false,
+        "markerStartShape": "circle",
+        "maxNeedleAngle": 320,
+        "maxTickAngle": 300,
+        "maxValue": 100,
+        "minValue": 0,
+        "needleColor": "#0099cc",
+        "needleCrossLimitDegrees": 5,
+        "needleLengthNeg": 0,
+        "needleTickGap": 0.05,
+        "needleWidth": 5,
+        "operatorName": "last",
+        "outerEdgeColor": "#0099cc",
+        "padding": 0.05,
+        "pivotColor": "#999999",
+        "pivotRadius": 0.1,
+        "showThresholdBandLowerRange": true,
+        "showThresholdBandMiddleRange": true,
+        "showThresholdBandOnGauge": true,
+        "showThresholdBandUpperRange": true,
+        "showThresholdStateOnBackground": false,
+        "showThresholdStateOnTitle": false,
+        "showThresholdStateOnValue": true,
+        "showTitle": true,
+        "showValue": true,
+        "showTickLabels": true,
+        "wrapValues": false,
+        "tickEdgeGap": 0.05,
+        "tickFont": "Inter",
+        "tickLabelColor": "#000000",
+        "tickLabelFontSize": 14,
+        "tickLengthMaj": 0.15,
+        "tickLengthMin": 0.05,
+        "tickMajorColor": "#0099CC",
+        "tickMapConfig": { "tickMaps": [], "enabled": true },
+        "tickMinorColor": "#000000",
+        "tickSpacingMajor": 10,
+        "tickSpacingMinor": 5,
+        "tickWidthMajor": 5,
+        "tickWidthMinor": 1,
+        "ticknessGaugeBasis": 200,
+        "titleFont": "Inter",
+        "titleFontSize": 22,
+        "titleYOffset": 0,
+        "unitsLabelColor": "#000000",
+        "valueFont": "Inter",
+        "valueFontSize": 22,
+        "valueYOffset": 0,
+        "zeroNeedleAngle": 40,
+        "zeroTickAngle": 60
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "P53465F745837BCFD" },
+          "max": 100,
+          "min": 0,
+          "noise": 2,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1,
+          "spread": 10,
+          "startValue": 50
+        }
+      ],
+      "title": "Smoke Gauge",
+      "type": "briangann-gauge-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": ["e2e", "smoke"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Gauge Smoke",
+  "uid": "briangann-gauge-smoke",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tests/gauge-smoke.spec.ts
+++ b/tests/gauge-smoke.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('gauge panel renders SVG with ticks, needle, and value label', async ({
+  gotoDashboardPage,
+}) => {
+  const dashboardPage = await gotoDashboardPage({ uid: 'briangann-gauge-smoke' });
+  const panel = dashboardPage.getPanelById(1);
+
+  // The panel emits one <svg> whose <g> wraps circles, threshold bands,
+  // ticks, tick labels, needle, value, and title. Filter to the first svg
+  // that has the viewBox we set in gauge_render (square viewport), which
+  // excludes the panel header icon svg.
+  const gaugeSvg = panel.locator.locator('svg[viewBox^="0,0,"]').first();
+  await expect(gaugeSvg).toBeVisible({ timeout: 10000 });
+
+  const group = gaugeSvg.locator('g').first();
+  await expect(group).toBeVisible();
+
+  // Threshold bands, edge circles, and needle all render as <path> elements.
+  // Under the smoke config we expect strictly more than one.
+  const paths = group.locator('path');
+  await expect.poll(async () => paths.count(), { timeout: 10000 }).toBeGreaterThan(1);
+
+  // Major tick labels plus the value and title labels render as <text> elements.
+  const texts = group.locator('text');
+  await expect.poll(async () => texts.count(), { timeout: 10000 }).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

Gives the e2e matrix a test that actually exercises this plugin, not just Grafana's chrome. Provisions a minimal dashboard and asserts the gauge SVG renders with its expected children.

## Changes

- `provisioning/dashboards/dashboards/D3Gauge-Smoke.json` — one gauge panel (uid `briangann-gauge-smoke`, title `Smoke Gauge`) bound to the existing `TestData DB` datasource with a `random_walk` scenario. Percent unit, 0–100 range, three threshold steps. Same shape as the other provisioned dashboards so `pnpm server` picks it up.
- `tests/gauge-smoke.spec.ts` — imports `test, expect` from `@grafana/plugin-e2e`; uses `gotoDashboardPage({ uid: 'briangann-gauge-smoke' })` + `getPanelById(1)` to locate the panel container (works across Grafana 10/11/12/13+). Asserts:
  - gauge `<svg>` (disambiguated from the panel-header icon svg by its `viewBox="0,0,…"`) becomes visible within 10s
  - its first `<g>` is visible
  - that `<g>` has strictly more than one `<path>` (edge circles, threshold bands, needle)
  - that `<g>` has at least one `<text>` (major ticks + value/title)

## Why not assert on specific classes / test-ids

The gauge's SVG children don't carry plugin-authored `className` or `data-testid` — they're emitted by pure D3/JSX render functions (`gauge_render.tsx`). Adding testids just for this smoke test would be a UI change with no product value; element-type + count assertions catch the regressions this test is meant to catch.

## Verification

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm build`
- [x] `pnpm exec playwright test tests/gauge-smoke.spec.ts` locally (grafana-enterprise@12.2.0 via `pnpm server`) — passes in ~4s
- [x] `pnpm spellcheck`, `markdownlint-cli2 CHANGELOG.md` — clean
- [ ] CI green across the e2e matrix

## Follow-ups (not in this PR)

- Panel-level interaction tests (edit options, tickmaps, thresholds).
- Visual regression via Playwright screenshots once the render is stable.