### PR TITLE
test(e2e): panel-level interaction tests — options, thresholds, tickmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,10 @@ All changes noted here.
   3. Tick maps — clicking `Add Tick Map`, entering value `50` + text
      `HALF`, and asserting the gauge renders a `<text>` with `HALF` in
      place of the `50` tick label.
+  Tests skip on Grafana `<12.0.0` — the panel-editor chrome (options
+  group aria-labels, option-id `label[for]` attributes) only
+  stabilises around Grafana 12. The `gauge-smoke.spec.ts` render check
+  keeps coverage for 10.x / 11.x.
 
 ### Testing (interaction coverage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,23 @@ All changes noted here.
   one `<text>` label). The panel is located via `getPanelById(1)` and
   the gauge SVG is disambiguated from the panel-header icon by its
   `viewBox="0,0,…"` attribute.
+- Add panel-level interaction test `tests/gauge-interactions.spec.ts`
+  covering three edit-mode flows:
+  1. `Show Value on Gauge` toggle — text-element count drops when the
+     value label is hidden and returns when toggled back on.
+  2. `Show Threshold Band On Gauge` toggle — path-element count drops
+     when the three bands are hidden and returns when toggled back on.
+  3. Tick maps — clicking `Add Tick Map`, entering value `50` + text
+     `HALF`, and asserting the gauge renders a `<text>` with `HALF` in
+     place of the `50` tick label.
+
+### Testing (interaction coverage)
+
+- Add `data-testid="tickmap-add-button"` on the `Add Tick Map` button
+  in `TickMapEditor` and `data-testid="tickmap-value-input-<order>"` /
+  `data-testid="tickmap-text-input-<order>"` on the Value and Text
+  inputs in `TickMapItem`, so the tick-maps interaction test can
+  target them without relying on Grafana-generated class names.
 
 ### E2E Testing
 

--- a/src/components/TickMaps/TickMapEditor.tsx
+++ b/src/components/TickMaps/TickMapEditor.tsx
@@ -138,7 +138,7 @@ export const TickMapEditor: React.FC<Props> = ({ context, onChange }) => {
       <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--text-secondary)' }}>
         Replaces value at tick with specified text. The value setting must match one of the displayed values.
       </div>
-      <Button fill="solid" variant="primary" icon="plus" onClick={addItem}>
+      <Button data-testid="tickmap-add-button" fill="solid" variant="primary" icon="plus" onClick={addItem}>
         Add Tick Map
       </Button>
       {tracker.map((trackerItem: TickMapItemTracker, index: number) => {

--- a/src/components/TickMaps/TickMapItem.tsx
+++ b/src/components/TickMaps/TickMapItem.tsx
@@ -27,6 +27,7 @@ export const TickMapItem: React.FC<TickMapItemProps> = (props) => {
           </Field>
           <Field label="Value" description="Tick Value where the text will be placed" disabled={!tickMap.enabled}>
             <Input
+              data-testid={`tickmap-value-input-${tickMap.order}`}
               value={tickMap.value}
               placeholder=""
               onChange={(e) => setter(tickMap.order, { ...tickMap, value: e.currentTarget.value })}
@@ -34,6 +35,7 @@ export const TickMapItem: React.FC<TickMapItemProps> = (props) => {
           </Field>
           <Field label="Text" description="Text to be displayed for tick value" disabled={!tickMap.enabled}>
             <Input
+              data-testid={`tickmap-text-input-${tickMap.order}`}
               value={tickMap.text}
               placeholder=""
               onChange={(e) => setter(tickMap.order, { ...tickMap, text: e.currentTarget.value })}

--- a/tests/gauge-interactions.spec.ts
+++ b/tests/gauge-interactions.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, PanelEditPage } from '@grafana/plugin-e2e';
+
+const SMOKE_DASHBOARD = { uid: 'briangann-gauge-smoke' };
+const PANEL_ID = '1';
+
+// The gauge's own <svg> is the one whose viewBox starts at "0,0,"; the
+// panel-header icon <svg> has a different shape.
+const gaugeSvg = (panelEditPage: PanelEditPage) =>
+  panelEditPage.panel.locator.locator('svg[viewBox^="0,0,"]').first();
+
+test.describe('gauge panel — edit-mode interactions', () => {
+  test('toggling "Show Value on Gauge" hides and restores the value label', async ({
+    gotoPanelEditPage,
+  }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: SMOKE_DASHBOARD, id: PANEL_ID });
+
+    const svg = gaugeSvg(panelEditPage);
+    await expect(svg).toBeVisible({ timeout: 10000 });
+
+    const texts = svg.locator('g').first().locator('text');
+    const initialCount = await texts.count();
+    expect(initialCount).toBeGreaterThan(0);
+
+    // Grafana renders a <label> over the hidden switch input; clicking the
+    // input is intercepted by the label, so target the label directly.
+    const showValueLabel = panelEditPage.ctx.page
+      .locator('label[for="briangann-gauge-panel-showValue"]')
+      .first();
+    await expect(showValueLabel).toBeVisible();
+    await showValueLabel.click();
+
+    await expect
+      .poll(async () => texts.count(), { timeout: 5000 })
+      .toBeLessThan(initialCount);
+
+    // Flip back on and confirm the count returns
+    await showValueLabel.click();
+    await expect
+      .poll(async () => texts.count(), { timeout: 5000 })
+      .toBe(initialCount);
+  });
+
+  test('toggling "Show Threshold Band On Gauge" drops the threshold band paths', async ({
+    gotoPanelEditPage,
+  }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: SMOKE_DASHBOARD, id: PANEL_ID });
+
+    const svg = gaugeSvg(panelEditPage);
+    await expect(svg).toBeVisible({ timeout: 10000 });
+
+    const paths = svg.locator('g').first().locator('path');
+    const initialPathCount = await paths.count();
+    expect(initialPathCount).toBeGreaterThan(1);
+
+    await panelEditPage.collapseSection('Thresholds');
+
+    const thresholdLabel = panelEditPage.ctx.page
+      .locator('label[for="briangann-gauge-panel-showThresholdBandOnGauge"]')
+      .first();
+    await expect(thresholdLabel).toBeVisible();
+    await thresholdLabel.click();
+
+    await expect
+      .poll(async () => paths.count(), { timeout: 5000 })
+      .toBeLessThan(initialPathCount);
+
+    // Restore
+    await thresholdLabel.click();
+    await expect
+      .poll(async () => paths.count(), { timeout: 5000 })
+      .toBe(initialPathCount);
+  });
+
+  test('adding a tick map replaces a tick label with the mapped text', async ({
+    gotoPanelEditPage,
+  }) => {
+    const panelEditPage = await gotoPanelEditPage({ dashboard: SMOKE_DASHBOARD, id: PANEL_ID });
+
+    const svg = gaugeSvg(panelEditPage);
+    await expect(svg).toBeVisible({ timeout: 10000 });
+
+    // Expand the Tick Maps category in the options pane
+    await panelEditPage.collapseSection('Tick Maps');
+
+    // Click "Add Tick Map", then fill the first row with value 50 → HALF
+    const addButton = panelEditPage.ctx.page.getByTestId('tickmap-add-button');
+    await expect(addButton).toBeVisible();
+    await addButton.click();
+
+    const valueInput = panelEditPage.ctx.page.getByTestId('tickmap-value-input-0');
+    const textInput = panelEditPage.ctx.page.getByTestId('tickmap-text-input-0');
+    await expect(valueInput).toBeVisible();
+    await valueInput.fill('50');
+    await textInput.fill('HALF');
+    // Commit the last input so React fires the onChange → debounce flush
+    await textInput.press('Tab');
+
+    const mappedLabel = svg
+      .locator('g')
+      .first()
+      .locator('text')
+      .filter({ hasText: 'HALF' });
+    await expect(mappedLabel).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/tests/gauge-interactions.spec.ts
+++ b/tests/gauge-interactions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, PanelEditPage } from '@grafana/plugin-e2e';
+import { gte } from 'semver';
 
 const SMOKE_DASHBOARD = { uid: 'briangann-gauge-smoke' };
 const PANEL_ID = '1';
@@ -8,7 +9,20 @@ const PANEL_ID = '1';
 const gaugeSvg = (panelEditPage: PanelEditPage) =>
   panelEditPage.panel.locator.locator('svg[viewBox^="0,0,"]').first();
 
+// Panel editor chrome (options group aria-labels, option-id label `for`
+// attributes) only stabilises around Grafana 12. Skip interaction tests
+// on 10.x/11.x — the smoke test still covers those versions at the
+// render level.
+const MIN_GRAFANA_FOR_INTERACTIONS = '12.0.0';
+
 test.describe('gauge panel — edit-mode interactions', () => {
+  test.beforeEach(async ({ grafanaVersion }) => {
+    test.skip(
+      !gte(grafanaVersion, MIN_GRAFANA_FOR_INTERACTIONS),
+      `panel edit-mode chrome differs on Grafana <${MIN_GRAFANA_FOR_INTERACTIONS}`
+    );
+  });
+
   test('toggling "Show Value on Gauge" hides and restores the value label', async ({
     gotoPanelEditPage,
   }) => {


### PR DESCRIPTION
## Summary

Adds a panel-level interaction spec that exercises three edit-mode flows against the `briangann-gauge-smoke` dashboard from #172.

## Scenarios

1. **`Show Value on Gauge` toggle** — assert the gauge's `<text>` count drops when the value label is hidden and returns when toggled back on.
2. **`Show Threshold Band On Gauge` toggle** — assert the gauge's `<path>` count drops when the three bands are hidden and returns when toggled back on.
3. **Tick maps — add one entry via the custom editor** — click `Add Tick Map`, enter value `50` + text `HALF`, assert a `<text>` containing `HALF` appears in the gauge SVG.

All three use `gotoPanelEditPage({ dashboard: { uid: 'briangann-gauge-smoke' }, id: '1' })` and `PanelEditPage.collapseSection(<category>)` to expand the right options group.

## Why click labels instead of switches directly

Grafana renders a `<label for="briangann-gauge-panel-<option-path>">` over the hidden `<input type="checkbox">` used for boolean switches. Calling `click()` on the input itself is intercepted by the label and times out. Clicking the label (matched by its `for` attribute, with `.first()` to resolve a duplicate-label quirk) is the stable path.

## Source additions

Added `data-testid` attributes so the tick-maps interaction test can target the editor without relying on auto-generated class names:

- `TickMapEditor`: `tickmap-add-button`
- `TickMapItem`: `tickmap-value-input-<order>`, `tickmap-text-input-<order>`

## Verification

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test:ci` — 268 tests, 14 suites, all pass (TickMap unit tests unaffected by the new testids)
- [x] `pnpm exec playwright test tests/gauge-interactions.spec.ts` locally (grafana-enterprise@12.2.0 via `pnpm server`) — 4 tests pass in ~5s
- [x] `pnpm spellcheck`, `markdownlint-cli2 CHANGELOG.md` — clean
- [ ] CI green across the e2e matrix

## Follow-ups (not in this PR)

- More interaction coverage (threshold edit/add, tickmap delete/reorder, option combinations).
- Visual regression with Playwright screenshots once interaction coverage stabilises.