### PR TITLE
docs: add e2e-targeting rule to AGENTS.md §10 Testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,19 +386,29 @@ Check CI status with `gh pr checks <PR-number>`.
   `TickMapItem`, `RangeEditor`, etc.) render in this repo, so adding a `data-testid` prop
   is a one-line change and the most stable locator.
 - **If the element is rendered by Grafana's option builder (`.addBooleanSwitch`,
-  `.addTextInput`, …)** pick based on `grafanaDependency` in `src/plugin.json`:
-  - **`grafanaDependency` starts at `>=11.0.0` or higher:** use
+  `.addTextInput`, …)** pick based on the minimum Grafana version the test will run
+  against:
+  - **Grafana ≥ 11.0.0:** use
     `selectors.components.PanelEditor.OptionsPane.fieldInput(<label>)` from
     `@grafana/plugin-e2e`. Resolves to
-    `data-testid Panel editor option pane field input <label>` and is the officially
+    `data-testid Panel editor option pane field input <label>` — Grafana's officially
     supported selector.
-  - **`grafanaDependency` includes Grafana <11** (this repo today — `>=10.0.0`):
-    use the `label[for="<plugin-id>-<option-path>"]` pattern. The `for` attribute is
-    deterministically built from values we own (`plugin.json` `id` and the option's
-    `path` in `module.ts`), so it is stable across every Grafana version in the
-    matrix without writing a custom editor wrapper just to inject a testid. Wrap the
-    selector in `.first()` — some Grafana versions render the label twice in the
-    options pane.
+  - **Grafana ≥ 12.0.0:** `label[for="<plugin-id>-<option-path>"]` (with `.first()`) also
+    works. The `for` attribute is built from values we own (`plugin.json` `id` + option
+    `path` in `module.ts`), so it's stable on 12+ without writing a custom editor
+    wrapper. Do **not** rely on this selector below Grafana 12 — on 10.x and 11.x the
+    option pane renders without that id convention and the label is not found.
+- **Always gate edit-mode interaction tests on a Grafana version floor** via
+  `test.skip(!gte(grafanaVersion, '<floor>'), '…')` in a describe-level `beforeEach`.
+  Panel-editor chrome (Options group aria labels, option-id attributes, portal layout)
+  diverges enough across majors that a locator that passes on one version will often
+  fail on an earlier one. For this repo today the floor is **Grafana 12.0.0**. Keep
+  render-level smoke coverage on older versions via tests that only assert on the
+  rendered SVG, not on editor chrome.
+- **Verify on the matrix floor before declaring a locator stable.** Local verification
+  against one recent Grafana version (e.g. via `pnpm server`, which pins to a single
+  image) is not sufficient — CI runs the full matrix and will catch chrome differences
+  on 10.x / 11.x that the default dev image hides.
 
 #### GitHub Actions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,18 @@ Check CI status with `gh pr checks <PR-number>`.
   hex values.
 - Use `Array<T>` syntax for non-simple array types (ESLint rule).
 
+##### E2E targeting
+
+- **If the component is ours, add `data-testid`.** Our custom editors (`TickMapEditor`,
+  `TickMapItem`, `RangeEditor`, etc.) render in this repo, so adding a `data-testid` prop
+  is a one-line change and the most stable locator.
+- **If the element is rendered by Grafana's option builder (`.addBooleanSwitch`,
+  `.addTextInput`, …), use the `label[for="<plugin-id>-<option-path>"]` pattern.** The
+  `for` attribute is deterministically built from values we own (`plugin.json` `id` and
+  the option's `path` in `module.ts`), so it is stable across Grafana versions without
+  writing a custom editor wrapper just to inject a testid. Wrap the selector in
+  `.first()` — some Grafana versions render the label twice in the options pane.
+
 #### GitHub Actions
 
 Pin every third-party action to a **full-length commit SHA** with a trailing version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,11 +386,19 @@ Check CI status with `gh pr checks <PR-number>`.
   `TickMapItem`, `RangeEditor`, etc.) render in this repo, so adding a `data-testid` prop
   is a one-line change and the most stable locator.
 - **If the element is rendered by Grafana's option builder (`.addBooleanSwitch`,
-  `.addTextInput`, …), use the `label[for="<plugin-id>-<option-path>"]` pattern.** The
-  `for` attribute is deterministically built from values we own (`plugin.json` `id` and
-  the option's `path` in `module.ts`), so it is stable across Grafana versions without
-  writing a custom editor wrapper just to inject a testid. Wrap the selector in
-  `.first()` — some Grafana versions render the label twice in the options pane.
+  `.addTextInput`, …)** pick based on `grafanaDependency` in `src/plugin.json`:
+  - **`grafanaDependency` starts at `>=11.0.0` or higher:** use
+    `selectors.components.PanelEditor.OptionsPane.fieldInput(<label>)` from
+    `@grafana/plugin-e2e`. Resolves to
+    `data-testid Panel editor option pane field input <label>` and is the officially
+    supported selector.
+  - **`grafanaDependency` includes Grafana <11** (this repo today — `>=10.0.0`):
+    use the `label[for="<plugin-id>-<option-path>"]` pattern. The `for` attribute is
+    deterministically built from values we own (`plugin.json` `id` and the option's
+    `path` in `module.ts`), so it is stable across every Grafana version in the
+    matrix without writing a custom editor wrapper just to inject a testid. Wrap the
+    selector in `.first()` — some Grafana versions render the label twice in the
+    options pane.
 
 #### GitHub Actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,12 +128,18 @@ All changes noted here.
   `cking`, `importme`, `negotiables`, `zizmor`).
 - Add an **E2E targeting** subsection to `AGENTS.md` §10 Testing:
   - Ours → `data-testid`.
-  - Grafana option builder with `grafanaDependency` ≥ 11.0.0 →
+  - Grafana option builder ≥ 11.0.0 →
     `selectors.components.PanelEditor.OptionsPane.fieldInput(<label>)`
     via `@grafana/plugin-e2e`.
-  - Grafana option builder with `grafanaDependency` including <11 (this
-    repo today) → `label[for="<plugin-id>-<option-path>"]` with
-    `.first()`.
+  - Grafana option builder ≥ 12.0.0 → also
+    `label[for="<plugin-id>-<option-path>"]` with `.first()`. Do **not**
+    use this below Grafana 12 — confirmed failing on 10.0.13 / 10.2.9 /
+    11.1.13 / 11.5.10 in PR #173 CI.
+  - Always gate edit-mode interaction tests on a `grafanaVersion` floor
+    via `test.skip` in a describe-level `beforeEach` — panel-editor
+    chrome diverges across majors. This repo's current floor is 12.0.0.
+  - Always verify on the matrix floor (not just `pnpm server`'s default
+    image) before declaring a locator stable.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,10 +126,14 @@ All changes noted here.
 - `cspell.config.json`: add proper names and tool names referenced in
   the new template (`Andrej`, `Cherny`, `Donahoe`, `IJFW`, `Karpathy`,
   `cking`, `importme`, `negotiables`, `zizmor`).
-- Add an **E2E targeting** subsection to `AGENTS.md` §10 Testing: if
-  the component is ours, add `data-testid`; if Grafana's option builder
-  renders it (`.addBooleanSwitch`, `.addTextInput`, …), use the
-  `label[for="<plugin-id>-<option-path>"]` pattern with `.first()`.
+- Add an **E2E targeting** subsection to `AGENTS.md` §10 Testing:
+  - Ours → `data-testid`.
+  - Grafana option builder with `grafanaDependency` ≥ 11.0.0 →
+    `selectors.components.PanelEditor.OptionsPane.fieldInput(<label>)`
+    via `@grafana/plugin-e2e`.
+  - Grafana option builder with `grafanaDependency` including <11 (this
+    repo today) → `label[for="<plugin-id>-<option-path>"]` with
+    `.first()`.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ All changes noted here.
 - `cspell.config.json`: add proper names and tool names referenced in
   the new template (`Andrej`, `Cherny`, `Donahoe`, `IJFW`, `Karpathy`,
   `cking`, `importme`, `negotiables`, `zizmor`).
+- Add an **E2E targeting** subsection to `AGENTS.md` §10 Testing: if
+  the component is ours, add `data-testid`; if Grafana's option builder
+  renders it (`.addBooleanSwitch`, `.addTextInput`, …), use the
+  `label[for="<plugin-id>-<option-path>"]` pattern with `.first()`.
 
 ### New Features
 


### PR DESCRIPTION
## Summary

Codifies the E2E locator convention surfaced while writing `gauge-interactions.spec.ts` (PR #173), and corrects it based on the full-matrix CI findings from that PR.

## Rule (final)

1. **Component rendered by this repo** → add `data-testid`.
2. **Grafana option builder, ≥ 11.0.0** → use `selectors.components.PanelEditor.OptionsPane.fieldInput(<label>)` from `@grafana/plugin-e2e`. Officially supported selector.
3. **Grafana option builder, ≥ 12.0.0** → `label[for="<plugin-id>-<option-path>"]` (with `.first()`) also works. Do **not** use this below Grafana 12 — PR #173's CI confirmed it fails on 10.0.13, 10.2.9, 11.1.13, and 11.5.10.
4. **Always gate edit-mode interaction tests on a Grafana version floor** via `test.skip(!gte(grafanaVersion, '<floor>'), '…')` in a describe-level `beforeEach`. Panel-editor chrome diverges across majors; this repo's current floor is **12.0.0**. Keep older-version coverage at the render level via smoke tests.
5. **Verify on the matrix floor before declaring a locator stable.** `pnpm server` pins to a single Grafana image and hides chrome differences on older versions.

## Why the correction

My first draft claimed `label[for="<plugin-id>-<option-path>"]` was "stable across every Grafana version in the matrix". PR #173's CI proved that wrong — the `for`-attribute convention only applies on Grafana 12+.

## Verification

- [x] `markdownlint-cli2 AGENTS.md CHANGELOG.md` — 0 errors
- [x] `pnpm spellcheck` — 0 errors

## Related

- PR #173 adds the interaction tests this rule describes and applies the Grafana-≥12 skip gate that this rule codifies.