### PR TITLE
fix(ci): grant zizmor job permissions to upload SARIF

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -37,6 +37,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # Required so `zizmorcore/zizmor-action` can upload its SARIF report
+      # via `github/codeql-action/upload-sarif` into the Security tab.
+      security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ All changes noted here.
 - Remove `.github/dependabot.yml` (superseded by Renovate)
 - Add `.github/workflows/lint-actions.yml` — runs `actionlint` and
   `zizmor` on PRs and pushes to `main` that touch `.github/workflows/**`
+- Grant `security-events: write` and `actions: read` to the `zizmor` job
+  in `lint-actions.yml` so `zizmorcore/zizmor-action` can upload its
+  SARIF report via `github/codeql-action/upload-sarif`
+  (previously failed on `main` with "Resource not accessible by
+  integration")
 - Fix actionlint findings surfaced by the new workflow:
   - Quote `$GITHUB_OUTPUT`, `$PWD`, and metadata vars in `ci.yml`
     (SC2086); drop useless `cat` and consolidate `>>` redirects in


### PR DESCRIPTION
## Why

Run [24699372021](https://github.com/briangann/grafana-gauge-panel/actions/runs/24699372021)
on `main` failed in the `zizmor` job with:

> Resource not accessible by integration - https://docs.github.com/rest

The audit itself exited `0` (no security findings). What failed was
`zizmorcore/zizmor-action`'s internal call to
`github/codeql-action/upload-sarif`, which needs `security-events: write`
to publish findings into the repo's Security tab.

## Change

Add `security-events: write` and `actions: read` to the `zizmor` job in
`.github/workflows/lint-actions.yml`. Rest of the workflow permissions
model (top-level `permissions: {}`, `actionlint` job scoped to
`contents: read`, `persist-credentials: false` on checkout) is
unchanged.

## Verification

- This same workflow runs on the PR, so a green `zizmor` check here
  confirms the SARIF upload now succeeds.