### PR TITLE
ci(release-please): rename PAT to GH_PAT_TOKEN + auto-stamp CHANGELOG date

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,13 +65,18 @@ jobs:
           git fetch "${remote_url}" "${branch}"
           git checkout "${branch}"
 
-          if ! grep -qE "^## v${version} \(unreleased\)" CHANGELOG.md; then
+          # Escape dots in the version for regex use so we only touch the exact
+          # "## vX.Y.Z (unreleased)" header matching the version release-please
+          # just proposed. Any other (unreleased) sections in the changelog
+          # (for different versions) are left alone.
+          version_re=${version//./\\.}
+          if ! grep -qE "^## v${version_re} \(unreleased\)\$" CHANGELOG.md; then
             echo "::notice::No '## v${version} (unreleased)' header in CHANGELOG.md; nothing to stamp"
             exit 0
           fi
 
           today=$(date -u +%Y-%m-%d)
-          sed -i.bak -E "s|^## v${version} \(unreleased\)\$|## v${version} (${today})|" CHANGELOG.md
+          sed -i.bak -E "s|^## v${version_re} \(unreleased\)\$|## v${version} (${today})|" CHANGELOG.md
           rm CHANGELOG.md.bak
 
           if git diff --quiet CHANGELOG.md; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,58 @@ jobs:
           fi
           echo "GH_PAT_TOKEN authenticates (HTTP 200)."
 
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - id: release
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           # PAT (not GITHUB_TOKEN) so the tag push on release triggers release.yml.
           # GITHUB_TOKEN-originated events never trigger downstream workflows.
           token: ${{ secrets.GH_PAT_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Release-please does not manage CHANGELOG.md (skip-changelog: true).
+      # If the hand-authored changelog has a "## vX.Y.Z (unreleased)" header
+      # matching the version release-please just proposed, replace
+      # "(unreleased)" with today's UTC date on the release PR branch so
+      # the merged release commit already has the correct date stamped.
+      - name: Checkout release PR branch
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Stamp CHANGELOG release date on release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          pr_num=$(jq -r '.number' <<<"${PR_JSON}")
+          branch=$(gh pr view "${pr_num}" --json headRefName --jq '.headRefName')
+          version=$(jq -r '."."' .release-please-manifest.json)
+          echo "Release PR #${pr_num} on branch ${branch}, version ${version}"
+
+          remote_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch "${remote_url}" "${branch}"
+          git checkout "${branch}"
+
+          if ! grep -qE "^## v${version} \(unreleased\)" CHANGELOG.md; then
+            echo "::notice::No '## v${version} (unreleased)' header in CHANGELOG.md; nothing to stamp"
+            exit 0
+          fi
+
+          today=$(date -u +%Y-%m-%d)
+          sed -i.bak -E "s|^## v${version} \(unreleased\)\$|## v${version} (${today})|" CHANGELOG.md
+          rm CHANGELOG.md.bak
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "::notice::CHANGELOG.md unchanged after sed; date already stamped"
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): stamp v${version} release date"
+          git push "${remote_url}" "HEAD:${branch}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,25 +14,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Verify GH_ACCESS_TOKEN PAT is valid
+      - name: Verify GH_PAT_TOKEN PAT is valid
         env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::GH_ACCESS_TOKEN secret is empty or unset. Set it at https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions"
+            echo "::error::GH_PAT_TOKEN secret is empty or unset. Set it at https://github.com/${GITHUB_REPOSITORY}/settings/secrets/actions"
             exit 1
           fi
           code=$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/user)
           if [ "${code}" != "200" ]; then
-            echo "::error::GH_ACCESS_TOKEN authentication failed (HTTP ${code}). Token is likely expired or revoked — rotate at https://github.com/settings/tokens with 'repo' scope and update the secret."
+            echo "::error::GH_PAT_TOKEN authentication failed (HTTP ${code}). Token is likely expired or revoked — rotate at https://github.com/settings/tokens with 'repo' scope and update the secret."
             exit 1
           fi
-          echo "GH_ACCESS_TOKEN authenticates (HTTP 200)."
+          echo "GH_PAT_TOKEN authenticates (HTTP 200)."
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           # PAT (not GITHUB_TOKEN) so the tag push on release triggers release.yml.
           # GITHUB_TOKEN-originated events never trigger downstream workflows.
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_PAT_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ pnpm exec playwright test --ui                       # interactive Playwright
    reviews and updates the catalog. grafana.com is not updated automatically.
 
 **Tag push triggers `release.yml`:** release-please-action is passed
-`secrets.GH_ACCESS_TOKEN` (a PAT with `repo` scope) via its `token:` input.
+`secrets.GH_PAT_TOKEN` (a PAT with `repo` scope) via its `token:` input.
 Tags pushed by this PAT trigger downstream workflows; tags pushed by the default
 `GITHUB_TOKEN` would not (GitHub disallows workflow recursion from `GITHUB_TOKEN`).
 If the PAT expires or is rotated, the symptom is: release-please PR merges, tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,9 +250,13 @@ pnpm exec playwright test --ui                       # interactive Playwright
    **not** rewrite `CHANGELOG.md` content (`skip-changelog: true`).
 3. After release-please creates or updates the release PR, a follow-up job in the same
    workflow `sed`s `## vX.Y.Z (unreleased)` → `## vX.Y.Z (YYYY-MM-DD)` on the release
-   PR branch when the proposed version matches the unreleased header. If the versions
-   don't match (e.g. you predicted minor but release-please proposes patch), the job
-   emits a `::notice::` and skips — edit the header manually then.
+   PR branch when the proposed version matches the unreleased header. The match is
+   anchored to the exact proposed version, so it is safe to keep multiple
+   `(unreleased)` sections in `CHANGELOG.md` at once (e.g. a forward-staged `v2.2.0`
+   section above an about-to-ship `v2.1.1` section) — only the matching header is
+   stamped, the others are left untouched. If no header matches (e.g. you predicted
+   minor but release-please proposes patch), the job emits a `::notice::` and skips;
+   edit the header manually then.
 4. Merging the release PR creates the `v*` git tag and a GitHub release via release-please.
 5. The `release.yml` workflow (trigger: `push: tags: ['v*']`) builds/signs the plugin
    with `GRAFANA_ACCESS_POLICY_TOKEN`, attaches a build-provenance attestation, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,12 +241,18 @@ pnpm exec playwright test --ui                       # interactive Playwright
 
 **Release pipeline (end-to-end):**
 
-1. Conventional-commit merges land on `main`.
+1. Conventional-commit merges land on `main`. When merging feature/fix work, add a
+   `## vX.Y.Z (unreleased)` section at the top of `CHANGELOG.md` describing the change
+   (`X.Y.Z` = the next expected version — patch for `fix:`, minor for `feat:`, major
+   for `feat!:`). Content under that header is hand-authored.
 2. `release-please.yml` runs on every push to `main` and opens/updates a
    **release PR** that bumps `package.json` and `.release-please-manifest.json`. It does
-   **not** touch `CHANGELOG.md` (`skip-changelog: true`) — that file is hand-authored.
-3. Before merging the release PR, finalize `CHANGELOG.md` for the target version
-   (replace any `(unreleased)` marker with the release date, polish notes).
+   **not** rewrite `CHANGELOG.md` content (`skip-changelog: true`).
+3. After release-please creates or updates the release PR, a follow-up job in the same
+   workflow `sed`s `## vX.Y.Z (unreleased)` → `## vX.Y.Z (YYYY-MM-DD)` on the release
+   PR branch when the proposed version matches the unreleased header. If the versions
+   don't match (e.g. you predicted minor but release-please proposes patch), the job
+   emits a `::notice::` and skips — edit the header manually then.
 4. Merging the release PR creates the `v*` git tag and a GitHub release via release-please.
 5. The `release.yml` workflow (trigger: `push: tags: ['v*']`) builds/signs the plugin
    with `GRAFANA_ACCESS_POLICY_TOKEN`, attaches a build-provenance attestation, and


### PR DESCRIPTION
## Summary

### 1. Rename PAT secret (`91858f8`)
Rename `GH_ACCESS_TOKEN` → `GH_PAT_TOKEN` in `release-please.yml` and `AGENTS.md` to match the secret that now exists in the repo (same name already used by `cp-update.yml`). `GH_ACCESS_TOKEN` has been retired. Without this, every push to `main` would fail the release-please pre-flight step with `GH_ACCESS_TOKEN secret is empty or unset`.

### 2. Auto-stamp CHANGELOG release date (`1c88880`)
Release-please is configured with `skip-changelog: true` because `CHANGELOG.md` is hand-authored. This adds a follow-up job in the same workflow that, after release-please opens or updates a release PR, checks out the PR branch and replaces a matching `## vX.Y.Z (unreleased)` header with `## vX.Y.Z (YYYY-MM-DD)`.

- Version match is derived from `.release-please-manifest.json` on the release branch, so the header version must match what release-please proposed (e.g. if you wrote `feat!:` but only a patch section was added, you'll see the notice and need to edit manually).
- Skips cleanly (with `::notice::`, no failure) when the unreleased header is missing or the version doesn't match.
- Pushes to the release PR branch use `GH_PAT_TOKEN` so CI still fires on the PR.
- Checkout uses `persist-credentials: false`; token is injected into the remote URL inline (passes zizmor's `artipacked` audit).

## Test plan
- [x] `actionlint .github/workflows/release-please.yml` — clean
- [x] `zizmor .github/workflows/release-please.yml` — no findings
- [x] `grep -r GH_ACCESS_TOKEN .github/ AGENTS.md` — no matches
- [ ] After merge: next release-please run on `main` passes pre-flight (HTTP 200)
- [ ] When the next release PR opens: stamper either stamps the CHANGELOG or emits a clear `::notice::`