### PR TITLE
fix(release-please): read branch name from PR_JSON, not gh pr view

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,7 @@ jobs:
           set -euo pipefail
 
           pr_num=$(jq -r '.number' <<<"${PR_JSON}")
-          branch=$(gh pr view "${pr_num}" --json headRefName --jq '.headRefName')
+          branch=$(jq -r '.headBranchName' <<<"${PR_JSON}")
           echo "Release PR #${pr_num} on branch ${branch}"
 
           manifest=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${branch}" --jq '.content' | base64 -d)


### PR DESCRIPTION
## Why

Run 24725453108 failed with `fatal: not a git repository (or any of the parent directories): .git` in the CHANGELOG stamper step. PR #183 dropped `actions/checkout` (the stamper now uses the Contents API), but left a `gh pr view` call which needs a local checkout to infer the repo.

Side note: **PR #184's bump commit came back Verified** — the GitHub App token path works. This PR fixes only the stamper.

## Fix

Parse `headBranchName` directly out of the PR JSON release-please already emits via `steps.release.outputs.pr`. No git context needed.

```diff
- branch=$(gh pr view "${pr_num}" --json headRefName --jq '.headRefName')
+ branch=$(jq -r '.headBranchName' <<<"${PR_JSON}")
```

## Test plan
- [x] `actionlint` — clean
- [x] `zizmor` — no findings
- [ ] After merge: next release-please run's stamper step (if an (unreleased) header matches the proposed version) should succeed and produce a verified stamper commit on the release PR branch