### PR TITLE
docs(changelog): rename v2.1.0 section to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All changes noted here.
 
-## v2.1.0 (2026-04-21)
+## v2.2.0 (2026-04-21)
 
 ### Bug Fixes (Rendering and Migration)
 


### PR DESCRIPTION
## Why

The hand-written `## v2.1.0 (2026-04-21)` section describes every commit since v2.0.1 — exactly what release-please is about to ship as **v2.2.0** (PR #184). Rename the heading so the published changelog matches the git tag and grafana.com catalog entry.

## Merge order

1. **#185** — stamper fix (`gh pr view` → `jq` parse of PR_JSON)
2. **this PR** — CHANGELOG heading rename
3. **#184** — release-please's 2.2.0 bump PR

After step 2 lands on main, release-please re-runs and updates #184. The fixed stamper will see `## v2.2.0 (2026-04-21)` already dated and emit a `::notice::` → no-op.

## Test plan
- [x] `pnpm spellcheck` — clean
- [ ] After merge: release-please run updates #184 without stamper failure