### PR TITLE
ci(release-please): pin tag format to vX.Y.Z (drop component prefix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,13 @@ pnpm exec playwright test --ui                       # interactive Playwright
    stamped, the others are left untouched. If no header matches (e.g. you predicted
    minor but release-please proposes patch), the job emits a `::notice::` and skips;
    edit the header manually then.
-4. Merging the release PR creates the `v*` git tag and a GitHub release via release-please.
+4. Merging the release PR creates the `vX.Y.Z` git tag and a GitHub release via
+   release-please. The tag name format is enforced by
+   `release-please-config.json` (`include-v-in-tag: true`,
+   `include-component-in-tag: false`). Do **not** flip either of those — the
+   `grafana/plugin-actions/build-plugin` action in the next step hard-checks
+   `"v${PLUGIN_VERSION}" == "${GITHUB_TAG}"` and will fail fast if the tag is
+   anything other than `v<version>`.
 5. The `release.yml` workflow (trigger: `push: tags: ['v*']`) builds/signs the plugin
    with `GRAFANA_ACCESS_POLICY_TOKEN`, attaches a build-provenance attestation, and
    publishes a **signed `.zip`** plus `.zip.sha1` to a GitHub **draft** release.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "package-name": "briangann-gauge-panel",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "skip-changelog": true,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## Why

release-please shipped v2.2.0 as tag `briangann-gauge-panel-v2.2.0` (include-component-in-tag defaults to true). Two downstream breakages:

1. `release.yml` triggers on `tags: ['v*']`, so the prefixed tag did not fire it. No signed `.zip` was attached to the v2.2.0 release.
2. `grafana/plugin-actions/build-plugin` hard-checks `"v${PLUGIN_VERSION}" == "${GITHUB_TAG}"` — we can't just broaden the trigger pattern, the action would fail on any non-`v<version>` tag.

## Fix

- `release-please-config.json`: add `"include-component-in-tag": false`. Future tags will be `v2.3.0`, `v2.4.0`, ...
- `AGENTS.md §Release` notes the constraint so nobody flips the flag back on without knowing the build-plugin check will break.

## Not in this PR — manual cleanup for v2.2.0

After merge, the v2.2.0 release still has no assets. To fix that specific release:

```bash
# Delete the component-prefixed tag+release (safe: no assets, nothing downloaded)
gh release delete briangann-gauge-panel-v2.2.0 --yes --cleanup-tag

# Create the v-prefixed tag at the PR #184 merge commit
git tag v2.2.0 16c64e5ba93bcf39f022ad09616c84028b7fab91
git push origin v2.2.0
```

That tag push fires `release.yml` → builds + signs + creates the draft release → publish + submit to grafana.com.

## Test plan

- [x] `jq . release-please-config.json` parses clean
- [ ] Next release (v2.3.0 path) produces tag `v2.3.0`, release.yml fires, draft release has signed zip