### PR TITLE
ci: run plugin-validator with full analyzer set, also on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,11 @@ jobs:
           ARCHIVE: ${{ steps.metadata.outputs.archive }}
           PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
 
-      - name: Check plugin.json
+      - name: Validate plugin package
         run: |
           docker run --pull=always \
             -v "$PWD/${ARCHIVE}:/archive.zip" \
-            grafana/plugin-validator-cli -analyzer=metadatavalid /archive.zip
+            grafana/plugin-validator-cli /archive.zip
         env:
           ARCHIVE: ${{ steps.metadata.outputs.archive }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: grafana/plugin-actions/build-plugin@8b12a2d6fa5fc0939a6bf75905453d4b505ef29a # build-plugin/v1.2.0
+      - id: build
+        uses: grafana/plugin-actions/build-plugin@8b12a2d6fa5fc0939a6bf75905453d4b505ef29a # build-plugin/v1.2.0
         with:
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
           attestation: true
+
+      - name: Validate signed plugin package
+        run: |
+          docker run --pull=always \
+            -v "$PWD/${ARCHIVE}:/archive.zip" \
+            grafana/plugin-validator-cli /archive.zip
+        env:
+          ARCHIVE: ${{ steps.build.outputs.archive }}


### PR DESCRIPTION
## Summary

1. **ci.yml** — drop `-analyzer=metadatavalid` so `plugin-validator-cli` runs the full default analyzer set (manifest, signature, readme, templatereadme, screenshots, org, …). Previously only the plugin.json schema was checked.
2. **release.yml** — add a new `Validate signed plugin package` step after `grafana/plugin-actions/build-plugin` produces the signed `.zip`. Fails the workflow before a draft GitHub release would be created if the package wouldn't survive submission review.

Both steps run the same `grafana/plugin-validator-cli` docker image, mounting the produced archive at `/archive.zip`.

## Test plan

- [x] `actionlint` — clean
- [x] `zizmor` — no findings
- [ ] After merge: PR CI runs the expanded validator against the PR build
- [ ] Next `v*` tag push: release.yml validates the signed `.zip` before the draft release is published