### PR TITLE
fix(ci): replace setup-node pnpm cache with explicit restore-keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,16 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -189,8 +197,16 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
 
       - name: Install dev dependencies
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Problem

`actions/setup-node` with `cache: 'pnpm'` does not support `restore-keys`. Every `pnpm-lock.yaml` change creates a fresh ~130MB cache entry with no fallback to previous caches. This caused 13 entries (~1.7GB) to accumulate before manual cleanup.

## Fix

Replace the built-in cache with an explicit `actions/cache` step that includes `restore-keys` in both the `build` and `playwright-tests` jobs.

With `restore-keys`, a lockfile change restores the nearest previous cache (partial hit), pnpm only fetches the delta, and the new cache is saved under the exact key. Cache count stays at 1–2 entries instead of accumulating indefinitely.