### PR TITLE
fix(renovate): group vulnerability alerts into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "enabled": true,
+    "groupName": "security",
     "labels": ["dependencies", "security"],
     "prPriority": 10,
     "schedule": ["at any time"],


### PR DESCRIPTION
## Problem

Each CVE triggers its own Renovate security PR (schedule: "at any time"), causing one lockfile change per vulnerability. With 13 open vulnerabilities that's 13 separate CI runs and 13 new cache entries — which is what filled the cache to 1.7GB this week.

## Fix

Add `"groupName": "security"` to `vulnerabilityAlerts`. All pending CVE fixes are batched into a single PR instead of one per vulnerability.