### PR TITLE
ci: reduce artifact retention from 5 to 3 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         with:
           name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
           path: ${{ steps.metadata.outputs.plugin-id }}
-          retention-days: 5
+          retention-days: 3
 
   resolve-versions:
     name: Resolve e2e images
@@ -251,7 +251,7 @@ jobs:
       #   with:
       #     name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
       #     path: grafana-server.log
-      #     retention-days: 5
+      #     retention-days: 3
 
   # publish-report:
   #   if: ${{ always() && !cancelled() }}


### PR DESCRIPTION
## Summary

- Reduces artifact retention from 5 days to 3 days to keep Actions storage usage low

## Test plan

- [ ] Verify CI passes
- [ ] Confirm artifacts expire after 3 days